### PR TITLE
Upgrade to Swift 3.0

### DIFF
--- a/Swift VectorBoolean.xcodeproj/project.pbxproj
+++ b/Swift VectorBoolean.xcodeproj/project.pbxproj
@@ -265,14 +265,17 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Startside Softworks";
 				TargetAttributes = {
 					6356E1771B4CD83A00420351 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					6356E18C1B4CD83A00420351 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 						TestTargetID = 6356E1771B4CD83A00420351;
 					};
 				};
@@ -416,8 +419,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -462,8 +467,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -482,6 +489,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -491,10 +499,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Swift VectorBoolean/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.starside.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -502,10 +515,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Swift VectorBoolean/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.starside.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -513,6 +529,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -522,6 +539,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.starside.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift VectorBoolean.app/Swift VectorBoolean";
 			};
 			name = Debug;
@@ -530,11 +548,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Swift VectorBooleanTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.starside.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Swift VectorBoolean.app/Swift VectorBoolean";
 			};
 			name = Release;

--- a/Swift VectorBoolean/AppDelegate.swift
+++ b/Swift VectorBoolean/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
 
-  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     return true
   }
 
-  func applicationWillResignActive(application: UIApplication) {
+  func applicationWillResignActive(_ application: UIApplication) {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
   }
 
-  func applicationDidEnterBackground(application: UIApplication) {
+  func applicationDidEnterBackground(_ application: UIApplication) {
     // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
   }
 
-  func applicationWillEnterForeground(application: UIApplication) {
+  func applicationWillEnterForeground(_ application: UIApplication) {
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
   }
 
-  func applicationDidBecomeActive(application: UIApplication) {
+  func applicationDidBecomeActive(_ application: UIApplication) {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
   }
 
-  func applicationWillTerminate(application: UIApplication) {
+  func applicationWillTerminate(_ application: UIApplication) {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
   }
 

--- a/Swift VectorBoolean/CanvasView.swift
+++ b/Swift VectorBoolean/CanvasView.swift
@@ -9,16 +9,16 @@
 import UIKit
 
 enum DisplayMode {
-  case Original
-  case Union
-  case Intersect
-  case Subtract
-  case Join
+  case original
+  case union
+  case intersect
+  case subtract
+  case join
 }
 
 class PathItem {
-  private var path: UIBezierPath
-  private var color: UIColor
+  fileprivate var path: UIBezierPath
+  fileprivate var color: UIColor
 
   init(path:UIBezierPath,color:UIColor) {
     self.path = path
@@ -28,15 +28,15 @@ class PathItem {
 
 class CanvasView: UIView {
 
-  private var paths: [PathItem] = []
+  fileprivate var paths: [PathItem] = []
   var boundsOfPaths: CGRect = CGRect.zero
 
-  private var _unionPath: UIBezierPath?
-  private var _intersectPath: UIBezierPath?
-  private var _differencePath: UIBezierPath?
-  private var _xorPath: UIBezierPath?
+  fileprivate var _unionPath: UIBezierPath?
+  fileprivate var _intersectPath: UIBezierPath?
+  fileprivate var _differencePath: UIBezierPath?
+  fileprivate var _xorPath: UIBezierPath?
 
-  var displayMode: DisplayMode = .Original {
+  var displayMode: DisplayMode = .original {
     didSet(previousMode) {
       if displayMode != previousMode {
         setNeedsDisplay()
@@ -58,7 +58,7 @@ class CanvasView: UIView {
     _xorPath = nil
   }
 
-  func addPath(path: UIBezierPath, withColor color: UIColor) {
+  func addPath(_ path: UIBezierPath, withColor color: UIColor) {
     paths.append(PathItem(path: path, color: color))
     // we clear these because they're no longer valid
     _unionPath = nil
@@ -67,13 +67,13 @@ class CanvasView: UIView {
     _xorPath = nil
   }
 
-  private var viewScale = 1.0
+  fileprivate var viewScale = 1.0
 
-  private var decorationLineWidth: CGFloat {
+  fileprivate var decorationLineWidth: CGFloat {
     return CGFloat(1.5 / viewScale)
   }
 
-  func BoxFrame(point: CGPoint) -> CGRect
+  func BoxFrame(_ point: CGPoint) -> CGRect
   {
     let visualWidth = CGFloat(9 / viewScale)
     let offset = visualWidth / 2
@@ -84,10 +84,10 @@ class CanvasView: UIView {
     return CGRect(x: left, y: bottom, width: visualWidth, height: visualWidth)
   }
 
-  override func drawRect(rect: CGRect) {
+  override func draw(_ rect: CGRect) {
     // fill with white before going further
     let background = UIBezierPath(rect: rect)
-    UIColor.whiteColor().setFill()
+    UIColor.white.setFill()
     background.fill()
 
     // When running my Xcode tests for geometry I want to
@@ -100,7 +100,7 @@ class CanvasView: UIView {
     // calculate a useful scale and offset for drawing these paths
     // as large as possible in the middle of the display
     // expand size by 20 to provide a margin
-    let expandedPathBounds = CGRectInset(boundsOfPaths, -10, -10)
+    let expandedPathBounds = boundsOfPaths.insetBy(dx: -10, dy: -10)
     let pSz = expandedPathBounds.size
     let pOr = expandedPathBounds.origin
     let vSz = self.bounds.size
@@ -114,45 +114,45 @@ class CanvasView: UIView {
     // obtain context
     let ctx = UIGraphicsGetCurrentContext()
 
-    CGContextSaveGState(ctx);
+    ctx?.saveGState();
 
     if scale == scaleX {
       let xTranslate = -(pOr.x * scale)
       let yTranslate = vSz.height - ((vSz.height-pSz.height*scale)/2.0) + (pOr.y*scale)
-      CGContextTranslateCTM(ctx, xTranslate, yTranslate)
-      CGContextScaleCTM(ctx, scale, -scale);
+      ctx?.translateBy(x: xTranslate, y: yTranslate)
+      ctx?.scaleBy(x: scale, y: -scale);
     } else {
       let xTranslate = ((vSz.width - pSz.width*scale)/2.0) - (pOr.x*scale)
       let yTranslate = vSz.height + (pOr.y * scale)
-      CGContextTranslateCTM(ctx, xTranslate, yTranslate)
-      CGContextScaleCTM(ctx, scale, -scale);
+      ctx?.translateBy(x: xTranslate, y: yTranslate)
+      ctx?.scaleBy(x: scale, y: -scale);
     }
 
     // Draw shapes now
 
     switch displayMode {
 
-    case .Original:
+    case .original:
       drawOriginal()
 
-    case .Union:
+    case .union:
       drawUnion()
 
-    case .Intersect:
+    case .intersect:
       drawIntersect()
 
-    case .Subtract:
+    case .subtract:
       drawSubtract()
 
-    case .Join:
+    case .join:
       drawJoin()
     }
 
     // All done
-    CGContextRestoreGState(ctx)
+    ctx?.restoreGState()
   }
 
-  private func drawOriginal() {
+  fileprivate func drawOriginal() {
     // Draw shapes now
 
     for pathItem in paths {
@@ -173,37 +173,37 @@ class CanvasView: UIView {
 
           switch item {
 
-          case let .Move(v):
+          case let .move(v):
             showMe = UIBezierPath(rect: BoxFrame(v))
 
-          case let .Line(v):
+          case let .line(v):
             // Convert lines to bezier curves as well.
             // Just set control point to be in the line formed by the end points
             showMe = UIBezierPath(rect: BoxFrame(v))
 
-          case .QuadCurve(let to, let cp):
+          case .quadCurve(let to, let cp):
             showMe = UIBezierPath(rect: BoxFrame(to))
-            UIColor.blackColor().setStroke()
-            let cp1 = UIBezierPath(ovalInRect: BoxFrame(cp))
+            UIColor.black.setStroke()
+            let cp1 = UIBezierPath(ovalIn: BoxFrame(cp))
             cp1.lineWidth = decorationLineWidth / 2
             cp1.stroke()
             break
 
-          case .CubicCurve(let to, let v1, let v2):
+          case .cubicCurve(let to, let v1, let v2):
             showMe = UIBezierPath(rect: BoxFrame(to))
-            UIColor.blackColor().setStroke()
-            let cp1 = UIBezierPath(ovalInRect: BoxFrame(v1))
+            UIColor.black.setStroke()
+            let cp1 = UIBezierPath(ovalIn: BoxFrame(v1))
             cp1.lineWidth = decorationLineWidth / 2
             cp1.stroke()
-            let cp2 = UIBezierPath(ovalInRect: BoxFrame(v2))
+            let cp2 = UIBezierPath(ovalIn: BoxFrame(v2))
             cp2.lineWidth = decorationLineWidth / 2
             cp2.stroke()
 
-          case .Close:
+          case .close:
             break
           }
 
-          UIColor.redColor().setStroke()
+          UIColor.red.setStroke()
           showMe?.lineWidth = decorationLineWidth
           showMe?.stroke()
         }
@@ -230,12 +230,12 @@ class CanvasView: UIView {
             (intersection: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool) in
 
             if intersection.isTangent {
-              UIColor.purpleColor().setStroke()
+              UIColor.purple.setStroke()
             } else {
-              UIColor.greenColor().setStroke()
+              UIColor.green.setStroke()
             }
             
-            let inter = UIBezierPath(ovalInRect: self.BoxFrame(intersection.location))
+            let inter = UIBezierPath(ovalIn: self.BoxFrame(intersection.location))
             inter.lineWidth = self.decorationLineWidth
             inter.stroke()
             
@@ -246,7 +246,7 @@ class CanvasView: UIView {
     }
   }
 
-  func drawEndPointsForPath(path: UIBezierPath) {
+  func drawEndPointsForPath(_ path: UIBezierPath) {
     let bezier = LRTBezierPathWrapper(path)
 
     //var previousPoint = CGPointZero
@@ -257,43 +257,43 @@ class CanvasView: UIView {
 
       switch item {
 
-      case let .Move(v):
+      case let .move(v):
         showMe = UIBezierPath(rect: BoxFrame(v))
 
-      case let .Line(v):
+      case let .line(v):
         // Convert lines to bezier curves as well.
         // Just set control point to be in the line formed by the end points
         showMe = UIBezierPath(rect: BoxFrame(v))
 
-      case .QuadCurve(let to, let cp):
+      case .quadCurve(let to, let cp):
         showMe = UIBezierPath(rect: BoxFrame(to))
-        UIColor.blackColor().setStroke()
-        let cp1 = UIBezierPath(ovalInRect: BoxFrame(cp))
+        UIColor.black.setStroke()
+        let cp1 = UIBezierPath(ovalIn: BoxFrame(cp))
         cp1.lineWidth = decorationLineWidth / 2
         cp1.stroke()
         break
 
-      case .CubicCurve(let to, let v1, let v2):
+      case .cubicCurve(let to, let v1, let v2):
         showMe = UIBezierPath(rect: BoxFrame(to))
-        UIColor.blackColor().setStroke()
-        let cp1 = UIBezierPath(ovalInRect: BoxFrame(v1))
+        UIColor.black.setStroke()
+        let cp1 = UIBezierPath(ovalIn: BoxFrame(v1))
         cp1.lineWidth = decorationLineWidth / 2
         cp1.stroke()
-        let cp2 = UIBezierPath(ovalInRect: BoxFrame(v2))
+        let cp2 = UIBezierPath(ovalIn: BoxFrame(v2))
         cp2.lineWidth = decorationLineWidth / 2
         cp2.stroke()
 
-      case .Close:
+      case .close:
         break
         //previousPoint = CGPointZero
       }
-      UIColor.redColor().setStroke()
+      UIColor.red.setStroke()
       showMe?.lineWidth = decorationLineWidth
       showMe?.stroke()
     }
   }
 
-  private func drawUnion() {
+  fileprivate func drawUnion() {
     if _unionPath == nil {
       if paths.count == 2 {
         _unionPath = paths[0].path.fb_union(paths[1].path)
@@ -311,7 +311,7 @@ class CanvasView: UIView {
     }
   }
 
-  private func drawIntersect() {
+  fileprivate func drawIntersect() {
     if _intersectPath == nil {
       if paths.count == 2 {
         _intersectPath = paths[0].path.fb_intersect(paths[1].path)
@@ -329,7 +329,7 @@ class CanvasView: UIView {
     }
   }
 
-  private func drawSubtract() {
+  fileprivate func drawSubtract() {
     if _differencePath == nil {
       if paths.count == 2 {
         _differencePath = paths[0].path.fb_difference(paths[1].path)
@@ -347,7 +347,7 @@ class CanvasView: UIView {
     }
   }
 
-  private func drawJoin() {
+  fileprivate func drawJoin() {
     if _xorPath == nil {
       if paths.count == 2 {
         _xorPath = paths[0].path.fb_xor(paths[1].path)

--- a/Swift VectorBoolean/OptionsViewController.swift
+++ b/Swift VectorBoolean/OptionsViewController.swift
@@ -15,7 +15,7 @@ class OptionsViewController: UIViewController {
   @IBOutlet var controlPointsSwitch: UISwitch!
   @IBOutlet var intersectionsSwitch: UISwitch!
 
-  override func viewWillAppear(animated: Bool) {
+  override func viewWillAppear(_ animated: Bool) {
     let currentPreferredSize = self.preferredContentSize
     self.preferredContentSize = CGSize.zero
     let newSize = CGSize(width: currentPreferredSize.width, height: 300)
@@ -27,18 +27,18 @@ class OptionsViewController: UIViewController {
     //preferredContentSize = CGSize(width: 0, height: 400)
 
     if let primeVC = primeVC {
-      controlPointsSwitch.on = primeVC.showEndpoints
-      intersectionsSwitch.on = primeVC.showIntersections
+      controlPointsSwitch.isOn = primeVC.showEndpoints
+      intersectionsSwitch.isOn = primeVC.showIntersections
     }
 
     let wantDoneButtonOnPhone = true
     // NOTE: The done button makes it easier to dismiss the controls.
 
-    if wantDoneButtonOnPhone && UI_USER_INTERFACE_IDIOM() != .Pad {
+    if wantDoneButtonOnPhone && UI_USER_INTERFACE_IDIOM() != .pad {
       navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Done",
-        style: .Plain,
+        style: .plain,
         target: self,
-        action: #selector(OptionsViewController.dismiss))
+        action: #selector(OptionsViewController.dismissVC))
     }
   }
 
@@ -48,20 +48,20 @@ class OptionsViewController: UIViewController {
   }
 
 
-  @IBAction func endpointsSwitchChanged(sender: UISwitch) {
+  @IBAction func endpointsSwitchChanged(_ sender: UISwitch) {
     if let primeVC = primeVC {
-      primeVC.showEndpoints = sender.on
+      primeVC.showEndpoints = sender.isOn
     }
   }
 
-  @IBAction func intersectionsSwitchChanged(sender: UISwitch) {
+  @IBAction func intersectionsSwitchChanged(_ sender: UISwitch) {
     if let primeVC = primeVC {
-      primeVC.showIntersections = sender.on
+      primeVC.showIntersections = sender.isOn
     }
   }
 
-  func dismiss() {
-    dismissViewControllerAnimated(true) {
+  func dismissVC() {
+    self.dismiss(animated: true) {
       self.primeVC?.popClosed()
     }
   }

--- a/Swift VectorBoolean/ShapesTableViewController.swift
+++ b/Swift VectorBoolean/ShapesTableViewController.swift
@@ -20,11 +20,11 @@ class ShapesTableViewController: UITableViewController {
     let wantCancelButtonOnPhone = true
     // NOTE: The cancel button makes it easier to dismiss the list.
 
-    if wantCancelButtonOnPhone && UI_USER_INTERFACE_IDIOM() != .Pad {
+    if wantCancelButtonOnPhone && UI_USER_INTERFACE_IDIOM() != .pad {
       navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Cancel",
-        style: .Plain,
+        style: .plain,
         target: self,
-        action: #selector(ShapesTableViewController.dismiss))
+        action: #selector(ShapesTableViewController.dismissVC))
     }
 
     // Uncomment the following line to preserve selection between presentations
@@ -34,8 +34,8 @@ class ShapesTableViewController: UITableViewController {
     // self.navigationItem.rightBarButtonItem = self.editButtonItem()
   }
 
-  override func viewWillAppear(animated: Bool) {
-    tableView.selectRowAtIndexPath(NSIndexPath(forItem: currentSelection, inSection: 0), animated: true, scrollPosition: UITableViewScrollPosition.Middle)
+  override func viewWillAppear(_ animated: Bool) {
+    tableView.selectRow(at: IndexPath(item: currentSelection, section: 0), animated: true, scrollPosition: UITableViewScrollPosition.middle)
   }
 
   override func didReceiveMemoryWarning() {
@@ -44,54 +44,54 @@ class ShapesTableViewController: UITableViewController {
   }
 
 
-  func dismiss() {
-    dismissViewControllerAnimated(true) {
+  func dismissVC() {
+    self.dismiss(animated: true) {
       self.primeVC?.popClosed()
     }
   }
 
   // MARK: - Table view data source
 
-  override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+  override func numberOfSections(in tableView: UITableView) -> Int {
     return 1
   }
 
-  override func tableView(_tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+  override func tableView(_ _tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
     return nil
   }
 
-  override func tableView(_tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+  override func tableView(_ _tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     if let shapeData = shapeData {
       return shapeData.count
     }
     return 19
   }
 
-  override func tableView (_tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+  override func tableView (_ _tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
-    let cell = UITableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: "testShapeCell")
+    let cell = UITableViewCell(style: UITableViewCellStyle.default, reuseIdentifier: "testShapeCell")
     if let shapeData = shapeData {
-      let testShape = shapeData.shapes[indexPath.row]
+      let testShape = shapeData.shapes[(indexPath as NSIndexPath).row]
       cell.textLabel!.text = testShape.label
     } else {
-      cell.textLabel!.text = "Broken \(indexPath.row)"
+      cell.textLabel!.text = "Broken \((indexPath as NSIndexPath).row)"
     }
-    if indexPath.row == currentSelection {
-      cell.accessoryType = UITableViewCellAccessoryType.Checkmark
+    if (indexPath as NSIndexPath).row == currentSelection {
+      cell.accessoryType = UITableViewCellAccessoryType.checkmark
     }
     return cell
   }
 
   // MARK: Table View Selection
 
-  override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 
     if let primeVC = primeVC {
-      primeVC.currentShapesetIndex = indexPath.row
+      primeVC.currentShapesetIndex = (indexPath as NSIndexPath).row
       primeVC.updateCanvas()
     }
 
-    dismiss()
+    dismissVC()
   }
 
 }

--- a/Swift VectorBoolean/TestShapes.swift
+++ b/Swift VectorBoolean/TestShapes.swift
@@ -15,11 +15,11 @@ protocol SampleShapeMaker {
 
 class TestShape {
   var label : String
-  private var _top : UIBezierPath?
-  private var _other : UIBezierPath?
+  fileprivate var _top : UIBezierPath?
+  fileprivate var _other : UIBezierPath?
 
   var boundsOfPaths : CGRect {
-    return CGRectUnion(top().bounds, other().bounds)
+    return top().bounds.union(other().bounds)
   }
 
   init(label:String) {
@@ -172,7 +172,7 @@ class TestShape_Rect_Over_Rect_w_Hole : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let holeyRectangle = UIBezierPath()
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
     addCircleAtPoint(CGPoint(x: 210, y: 200), withRadius: 125, toPath: holeyRectangle)
     return holeyRectangle
   }
@@ -190,8 +190,8 @@ class TestShape_Circle_Over_Two_Rects : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let rectangles = UIBezierPath()
-    rectangles.appendPath(UIBezierPath(rect: CGRect(x:  50, y: 5, width: 100, height: 400)))
-    rectangles.appendPath(UIBezierPath(rect: CGRect(x: 350, y: 5, width: 100, height: 400)))
+    rectangles.append(UIBezierPath(rect: CGRect(x:  50, y: 5, width: 100, height: 400)))
+    rectangles.append(UIBezierPath(rect: CGRect(x: 350, y: 5, width: 100, height: 400)))
     return rectangles
   }
 
@@ -229,7 +229,7 @@ class TestShape_Complex_Shapes : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let holeyRectangle = UIBezierPath()
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
     addCircleAtPoint(CGPoint(x: 210, y: 200), withRadius: 125, toPath: holeyRectangle)
 
     let rectangle = UIBezierPath(rect: CGRect(x: 180, y: 5, width: 100, height: 400))
@@ -253,8 +253,8 @@ class TestShape_Complex_Shapes2 : TestShape, SampleShapeMaker {
   }
   func common() -> (rectangles: UIBezierPath, circle: UIBezierPath) {
     let rectangles = UIBezierPath()
-    rectangles.appendPath(UIBezierPath(rect: CGRect(x:  50, y: 5, width: 100, height: 400)))
-    rectangles.appendPath(UIBezierPath(rect: CGRect(x: 350, y: 5, width: 100, height: 400)))
+    rectangles.append(UIBezierPath(rect: CGRect(x:  50, y: 5, width: 100, height: 400)))
+    rectangles.append(UIBezierPath(rect: CGRect(x: 350, y: 5, width: 100, height: 400)))
 
     let circle = UIBezierPath()
     addCircleAtPoint(CGPoint(x: 200, y: 200), withRadius: 185, toPath: circle)
@@ -286,11 +286,11 @@ class TestShape_Triangle_Inside_Rectangle : TestShape, SampleShapeMaker {
 
   func topShape() -> UIBezierPath {
     let path = UIBezierPath()
-    path.moveToPoint(CGPoint(x: 100, y: 400))
-    path.addLineToPoint(CGPoint(x: 400, y: 400))
-    path.addLineToPoint(CGPoint(x: 250, y: 250))
-    path.addLineToPoint(CGPoint(x: 100, y: 400))
-    path.closePath()
+    path.move(to: CGPoint(x: 100, y: 400))
+    path.addLine(to: CGPoint(x: 400, y: 400))
+    path.addLine(to: CGPoint(x: 250, y: 250))
+    path.addLine(to: CGPoint(x: 100, y: 400))
+    path.close()
     return path
   }
 }
@@ -307,12 +307,12 @@ class TestShape_Diamond_Overlapping_Rectangle : TestShape, SampleShapeMaker {
 
   func topShape() -> UIBezierPath {
     let path = UIBezierPath()
-    path.moveToPoint(CGPoint(x: 50, y: 250))
-    path.addLineToPoint(CGPoint(x: 150, y: 400))
-    path.addLineToPoint(CGPoint(x: 250, y: 250))
-    path.addLineToPoint(CGPoint(x: 150, y: 100))
-    path.addLineToPoint(CGPoint(x: 50, y: 250))
-    path.closePath()
+    path.move(to: CGPoint(x: 50, y: 250))
+    path.addLine(to: CGPoint(x: 150, y: 400))
+    path.addLine(to: CGPoint(x: 250, y: 250))
+    path.addLine(to: CGPoint(x: 150, y: 100))
+    path.addLine(to: CGPoint(x: 50, y: 250))
+    path.close()
 
     return path
   }
@@ -330,12 +330,12 @@ class TestShape_Diamond_Inside_Rectangle : TestShape, SampleShapeMaker {
 
   func topShape() -> UIBezierPath {
     let path = UIBezierPath()
-    path.moveToPoint(CGPoint(x: 100, y: 250))
-    path.addLineToPoint(CGPoint(x: 250, y: 400))
-    path.addLineToPoint(CGPoint(x: 400, y: 250))
-    path.addLineToPoint(CGPoint(x: 250, y: 100))
-    path.addLineToPoint(CGPoint(x: 100, y: 250))
-    path.closePath()
+    path.move(to: CGPoint(x: 100, y: 250))
+    path.addLine(to: CGPoint(x: 250, y: 400))
+    path.addLine(to: CGPoint(x: 400, y: 250))
+    path.addLine(to: CGPoint(x: 250, y: 100))
+    path.addLine(to: CGPoint(x: 100, y: 250))
+    path.close()
 
     return path
   }
@@ -369,8 +369,8 @@ class TestShape_More_Non_Overlapping_Contours : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let rectangles = UIBezierPath()
-    rectangles.appendPath(UIBezierPath(rect: CGRect(x:  100, y: 200, width: 200, height: 200)))
-    rectangles.appendPath(UIBezierPath(rect: CGRect(x: 175, y: 70, width: 50, height: 50)))
+    rectangles.append(UIBezierPath(rect: CGRect(x:  100, y: 200, width: 200, height: 200)))
+    rectangles.append(UIBezierPath(rect: CGRect(x: 175, y: 70, width: 50, height: 50)))
 
     return rectangles
   }
@@ -392,7 +392,7 @@ class TestShape_Concentric_Contours : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let holeyRectangle = UIBezierPath()
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
     addCircleAtPoint(CGPoint(x: 210, y: 200), withRadius: 125, toPath: holeyRectangle)
     return holeyRectangle
   }
@@ -412,7 +412,7 @@ class TestShape_More_Concentric_Contours : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let holeyRectangle = UIBezierPath()
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
     addCircleAtPoint(CGPoint(x: 210, y: 200), withRadius: 125, toPath: holeyRectangle)
     return holeyRectangle
   }
@@ -432,7 +432,7 @@ class TestShape_Circle_Overlapping_Hole : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let holeyRectangle = UIBezierPath()
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
     addCircleAtPoint(CGPoint(x: 210, y: 200), withRadius: 125, toPath: holeyRectangle)
     return holeyRectangle
   }
@@ -452,14 +452,14 @@ class TestShape_Rect_w_Hole_Over_Rect_w_Hole : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let holeyRectangle = UIBezierPath()
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
     addCircleAtPoint(CGPoint(x: 210, y: 200), withRadius: 125, toPath: holeyRectangle)
     return holeyRectangle
   }
 
   func topShape() -> UIBezierPath {
     let holeyRectangle = UIBezierPath()
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 225, y: 65, width: 160, height: 160)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 225, y: 65, width: 160, height: 160)))
     addCircleAtPoint(CGPoint(x: 305, y: 145), withRadius: 65, toPath: holeyRectangle)
     return holeyRectangle
   }
@@ -475,35 +475,35 @@ class TestShape_Curve_Overlapping_Rectangle : TestShape, SampleShapeMaker {
     let top : CGFloat = 65.0 + 160.0 / 3.0
 
     let path = UIBezierPath()
-    path.moveToPoint(CGPoint(x: 40, y: top))
-    path.addLineToPoint(CGPoint(x: 410, y: top))
-    path.addLineToPoint(CGPoint(x: 410, y: 50))
-    path.addLineToPoint(CGPoint(x: 40, y: 50))
-    path.addLineToPoint(CGPoint(x: 40, y: top))
-    path.closePath()
+    path.move(to: CGPoint(x: 40, y: top))
+    path.addLine(to: CGPoint(x: 410, y: top))
+    path.addLine(to: CGPoint(x: 410, y: 50))
+    path.addLine(to: CGPoint(x: 40, y: 50))
+    path.addLine(to: CGPoint(x: 40, y: top))
+    path.close()
 
     return path
   }
 
   func topShape() -> UIBezierPath {
     let curvyShape = UIBezierPath()
-    curvyShape.moveToPoint(CGPoint(x: 335, y: 203))
-    curvyShape.addCurveToPoint(CGPoint(x: 335, y: 200),
+    curvyShape.move(to: CGPoint(x: 335, y: 203))
+    curvyShape.addCurve(to: CGPoint(x: 335, y: 200),
       controlPoint1: CGPoint(x: 335, y: 202),
       controlPoint2: CGPoint(x: 335, y: 201))
-    curvyShape.addCurveToPoint(CGPoint(x: 270, y: 90),
+    curvyShape.addCurve(to: CGPoint(x: 270, y: 90),
       controlPoint1: CGPoint(x: 335, y: 153),
       controlPoint2: CGPoint(x: 309, y: 111))
-    curvyShape.addCurveToPoint(CGPoint(x: 240, y: 145),
+    curvyShape.addCurve(to: CGPoint(x: 240, y: 145),
       controlPoint1: CGPoint(x: 252, y: 102),
       controlPoint2: CGPoint(x: 240, y: 122))
-    curvyShape.addCurveToPoint(CGPoint(x: 305, y: 210),
+    curvyShape.addCurve(to: CGPoint(x: 305, y: 210),
       controlPoint1: CGPoint(x: 240, y: 181),
       controlPoint2: CGPoint(x: 269, y: 210))
-    curvyShape.addCurveToPoint(CGPoint(x: 335, y: 203),
+    curvyShape.addCurve(to: CGPoint(x: 335, y: 203),
       controlPoint1: CGPoint(x: 316, y: 210),
       controlPoint2: CGPoint(x: 326, y: 207))
-    curvyShape.closePath()
+    curvyShape.close()
 
     return curvyShape
   }
@@ -564,12 +564,12 @@ class TestShape_DebugQuadCurve : TestShape, SampleShapeMaker {
   func otherShapes() -> UIBezierPath {
 
     let quadTest = UIBezierPath()
-    quadTest.moveToPoint(CGPoint(x: 50, y: 50))
-    quadTest.addLineToPoint(CGPoint(x: 50, y: 100))
-    quadTest.addQuadCurveToPoint(CGPoint(x: 150, y: 100), controlPoint: CGPoint(x: 100, y: 150))
-    quadTest.addLineToPoint(CGPoint(x: 150, y: 50))
-    quadTest.addLineToPoint(CGPoint(x: 50, y: 50))
-    quadTest.closePath()
+    quadTest.move(to: CGPoint(x: 50, y: 50))
+    quadTest.addLine(to: CGPoint(x: 50, y: 100))
+    quadTest.addQuadCurve(to: CGPoint(x: 150, y: 100), controlPoint: CGPoint(x: 100, y: 150))
+    quadTest.addLine(to: CGPoint(x: 150, y: 50))
+    quadTest.addLine(to: CGPoint(x: 50, y: 50))
+    quadTest.close()
 
     return quadTest
   }
@@ -617,10 +617,10 @@ class TestShape_Debug002 : TestShape, SampleShapeMaker {
 
     let holeyRectangle = UIBezierPath()
     //holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 350, height: 300)))
-    holeyRectangle.appendPath(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 250, height: 200)))
+    holeyRectangle.append(UIBezierPath(rect: CGRect(x: 50, y: 50, width: 250, height: 200)))
     //addCircleAtPoint(CGPoint(x: 210, y: 200), withRadius: 125, toPath: holeyRectangle)
     //var circle = UIBezierPath(ovalInRect: CGRect(x: 210-125, y: 200-125, width: 250, height: 250))
-    let circle = UIBezierPath(ovalInRect: CGRect(x: 210-125, y: 200-125, width: 250, height: 250))
+    let circle = UIBezierPath(ovalIn: CGRect(x: 210-125, y: 200-125, width: 250, height: 250))
     //var allParts = holeyRectangle.fb_difference(circle)
     //var allParts = holeyRectangle.fb_union(circle)
     //var allParts = holeyRectangle.fb_intersect(circle)
@@ -653,13 +653,13 @@ class TestShape_Debug003 : TestShape, SampleShapeMaker {
 
   func otherShapes() -> UIBezierPath {
     let arc2 = UIBezierPath()
-    arc2.moveToPoint(CGPoint(x: 0, y: 250))
-    arc2.addCurveToPoint(
-      CGPoint(x: 250, y: 0),
+    arc2.move(to: CGPoint(x: 0, y: 250))
+    arc2.addCurve(
+      to: CGPoint(x: 250, y: 0),
       controlPoint1: CGPoint(x: 138.071198, y: 250),
       controlPoint2: CGPoint(x: 250, y: 138.071198)
     )
-    arc2.closePath()
+    arc2.close()
 
     //let checkMe = LRTBezierPathWrapper(circle)
 
@@ -668,13 +668,13 @@ class TestShape_Debug003 : TestShape, SampleShapeMaker {
 
   func topShape() -> UIBezierPath {
     let arc1 = UIBezierPath()
-    arc1.moveToPoint(CGPoint(x: 250, y: 250))
-    arc1.addCurveToPoint(
-      CGPoint(x: 0, y: 0),
+    arc1.move(to: CGPoint(x: 250, y: 250))
+    arc1.addCurve(
+      to: CGPoint(x: 0, y: 0),
       controlPoint1: CGPoint(x: 250, y: 111.928802),
       controlPoint2: CGPoint(x: 138.071198, y: 0)
     )
-    arc1.closePath()
+    arc1.close()
     
     return arc1
   }
@@ -729,37 +729,37 @@ class TestShape_Tiny_Rectangle_Overlapping_Rectangle : TestShape, SampleShapeMak
 
 // MARK: Extra functions
 
-func addCircleAtPoint(center: CGPoint, withRadius radius: CGFloat, toPath circle: UIBezierPath)
+func addCircleAtPoint(_ center: CGPoint, withRadius radius: CGFloat, toPath circle: UIBezierPath)
   {
     let FBMagicNumber: CGFloat = 0.55228475
 
     let controlPointLength = radius * FBMagicNumber
-    circle.moveToPoint(CGPoint(x: center.x - radius, y: center.y))
+    circle.move(to: CGPoint(x: center.x - radius, y: center.y))
     //[circle moveToPoint:NSMakePoint(center.x - radius, center.y)];
 
-    circle.addCurveToPoint(
-      CGPoint(x: center.x, y: center.y + radius),
+    circle.addCurve(
+      to: CGPoint(x: center.x, y: center.y + radius),
       controlPoint1: CGPoint(x: center.x - radius, y: center.y + controlPointLength),
       controlPoint2: CGPoint(x: center.x - controlPointLength, y: center.y + radius)
     )
     //  [circle curveToPoint:NSMakePoint(center.x, center.y + radius) controlPoint1:NSMakePoint(center.x - radius, center.y + controlPointLength) controlPoint2:NSMakePoint(center.x - controlPointLength, center.y + radius)];
 
-    circle.addCurveToPoint(
-      CGPoint(x: center.x + radius, y: center.y),
+    circle.addCurve(
+      to: CGPoint(x: center.x + radius, y: center.y),
       controlPoint1: CGPoint(x: center.x + controlPointLength, y: center.y + radius),
       controlPoint2: CGPoint(x: center.x + radius, y: center.y + controlPointLength)
     )
     //  [circle curveToPoint:NSMakePoint(center.x + radius, center.y) controlPoint1:NSMakePoint(center.x + controlPointLength, center.y + radius) controlPoint2:NSMakePoint(center.x + radius, center.y + controlPointLength)];
 
-    circle.addCurveToPoint(
-      CGPoint(x: center.x, y: center.y - radius),
+    circle.addCurve(
+      to: CGPoint(x: center.x, y: center.y - radius),
       controlPoint1: CGPoint(x: center.x + radius, y: center.y - controlPointLength),
       controlPoint2: CGPoint(x: center.x + controlPointLength, y: center.y - radius)
     )
     //  [circle curveToPoint:NSMakePoint(center.x, center.y - radius) controlPoint1:NSMakePoint(center.x + radius, center.y - controlPointLength) controlPoint2:NSMakePoint(center.x + controlPointLength, center.y - radius)];
 
-    circle.addCurveToPoint(
-      CGPoint(x: center.x - radius, y: center.y),
+    circle.addCurve(
+      to: CGPoint(x: center.x - radius, y: center.y),
       controlPoint1: CGPoint(x: center.x - controlPointLength, y: center.y - radius),
       controlPoint2: CGPoint(x: center.x - radius, y: center.y - controlPointLength)
     )

--- a/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Boolean.swift
+++ b/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Boolean.swift
@@ -14,10 +14,10 @@ extension UIBezierPath {
 
   // 15
   //- (NSBezierPath *) fb_union:(NSBezierPath *)path
-  func fb_union(path: UIBezierPath) -> UIBezierPath {
+  func fb_union(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
-    let resultGraph = thisGraph.unionWithBezierGraph(otherGraph)
+    let resultGraph = thisGraph.unionWithBezierGraph(otherGraph)!
     let result = resultGraph.bezierPath
     result.fb_copyAttributesFrom(self)
     return result
@@ -25,7 +25,7 @@ extension UIBezierPath {
 
   // 24
   //- (NSBezierPath *) fb_intersect:(NSBezierPath *)path
-  func fb_intersect(path: UIBezierPath) -> UIBezierPath {
+  func fb_intersect(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
     let result = thisGraph.intersectWithBezierGraph(otherGraph).bezierPath
@@ -35,7 +35,7 @@ extension UIBezierPath {
 
   // 33
   //- (NSBezierPath *) fb_difference:(NSBezierPath *)path
-  func fb_difference(path: UIBezierPath) -> UIBezierPath {
+  func fb_difference(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
     let result = thisGraph.differenceWithBezierGraph(otherGraph).bezierPath
@@ -45,7 +45,7 @@ extension UIBezierPath {
 
   // 42
   //- (NSBezierPath *) fb_xor:(NSBezierPath *)path
-  func fb_xor(path: UIBezierPath) -> UIBezierPath {
+  func fb_xor(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
     let result = thisGraph.xorWithBezierGraph(otherGraph).bezierPath

--- a/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Utilities.swift
+++ b/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Utilities.swift
@@ -29,7 +29,7 @@ extension UIBezierPath {
 
   // 57
   //- (void) fb_copyAttributesFrom:(NSBezierPath *)path
-  func fb_copyAttributesFrom(path: UIBezierPath) {
+  func fb_copyAttributesFrom(_ path: UIBezierPath) {
     self.lineWidth = path.lineWidth
     self.lineCapStyle = path.lineCapStyle
     self.lineJoinStyle = path.lineJoinStyle
@@ -39,7 +39,7 @@ extension UIBezierPath {
 
   // 103
   //+ (NSBezierPath *) circleAtPoint:(NSPoint)point
-  static func circleAtPoint(point: CGPoint) -> UIBezierPath {
+  static func circleAtPoint(_ point: CGPoint) -> UIBezierPath {
 
     let rect = CGRect(
       x: point.x - FBDebugPointSize * 0.5,
@@ -47,12 +47,12 @@ extension UIBezierPath {
       width: FBDebugPointSize,
       height: FBDebugPointSize);
 
-    return UIBezierPath(ovalInRect: rect)
+    return UIBezierPath(ovalIn: rect)
   }
 
   // 110
   //+ (NSBezierPath *) rectAtPoint:(NSPoint)point
-  static func rectAtPoint(point: CGPoint) -> UIBezierPath {
+  static func rectAtPoint(_ point: CGPoint) -> UIBezierPath {
 
     let rect = CGRect(
       x: point.x - FBDebugPointSize * 0.5,
@@ -64,7 +64,7 @@ extension UIBezierPath {
   }
 
   // 117
-  static func smallCircleAtPoint(point: CGPoint) -> UIBezierPath {
+  static func smallCircleAtPoint(_ point: CGPoint) -> UIBezierPath {
 
     let rect = CGRect(
       x: point.x - FBDebugSmallPointSize * 0.5,
@@ -72,12 +72,12 @@ extension UIBezierPath {
       width: FBDebugSmallPointSize,
       height: FBDebugSmallPointSize);
 
-    return UIBezierPath(ovalInRect: rect)
+    return UIBezierPath(ovalIn: rect)
   }
 
   // 124
   //+ (NSBezierPath *) smallRectAtPoint:(NSPoint)point
-  static func smallRectAtPoint(point: CGPoint) -> UIBezierPath {
+  static func smallRectAtPoint(_ point: CGPoint) -> UIBezierPath {
 
     let rect = CGRect(
       x: point.x - FBDebugSmallPointSize * 0.5,
@@ -90,7 +90,7 @@ extension UIBezierPath {
 
   // 131
   //+ (NSBezierPath *) triangleAtPoint:(NSPoint)point direction:(NSPoint)tangent
-  static func triangleAtPoint(point: CGPoint, direction tangent: CGPoint) -> UIBezierPath {
+  static func triangleAtPoint(_ point: CGPoint, direction tangent: CGPoint) -> UIBezierPath {
 
     let endPoint = FBAddPoint(point, point2: FBScalePoint(tangent, scale: FBDebugPointSize * 1.5))
     let normal1 = FBLineNormal(point, lineEnd: endPoint)
@@ -98,11 +98,11 @@ extension UIBezierPath {
     let basePoint1 = FBAddPoint(point, point2: FBScalePoint(normal1, scale: FBDebugPointSize * 0.5))
     let basePoint2 = FBAddPoint(point, point2: FBScalePoint(normal2, scale: FBDebugPointSize * 0.5))
     let path = UIBezierPath()
-    path.moveToPoint(basePoint1)
-    path.addLineToPoint(endPoint)
-    path.addLineToPoint(basePoint2)
-    path.addLineToPoint(basePoint1)
-    path.closePath()
+    path.move(to: basePoint1)
+    path.addLine(to: endPoint)
+    path.addLine(to: basePoint2)
+    path.addLine(to: basePoint1)
+    path.close()
 
     return path
   }

--- a/Swift VectorBoolean/VectorBoolean/CGPathBridge/LRTBezierPathWrapper.swift
+++ b/Swift VectorBoolean/VectorBoolean/CGPathBridge/LRTBezierPathWrapper.swift
@@ -11,7 +11,7 @@ import UIKit
 class LRTBezierPathWrapper {
 
   var elements: [PathElement]
-  private var _bezierPath : UIBezierPath
+  fileprivate var _bezierPath : UIBezierPath
 
   var bezierPath : UIBezierPath {
     get {
@@ -26,7 +26,7 @@ class LRTBezierPathWrapper {
   }
 
   func createElementsFromCGPath() {
-    let cgPath = _bezierPath.CGPath
+    let cgPath = _bezierPath.cgPath
 
     cgPath.apply({
       (e : PathElement) -> Void in

--- a/Swift VectorBoolean/VectorBoolean/FBBezierContour.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierContour.swift
@@ -12,8 +12,8 @@
 import UIKit
 
 enum FBContourInside {
-  case Filled
-  case Hole
+  case filled
+  case hole
 }
 //let myFBContourInsideExample = FBContourInside.Filled
 
@@ -24,17 +24,17 @@ class FBBezierContour {
 
   enum FBContourDirection
   {
-    case Clockwise
-    case AntiClockwise
+    case clockwise
+    case antiClockwise
   }
   //let myFBContourDirectionExample = FBContourDirection.AntiClockwise
 
-  private var _edges : [FBBezierCurve]
-  private var _overlaps : [FBContourOverlap]
-  private var _bounds : CGRect
-  private var _boundingRect : CGRect
-  private var _inside : FBContourInside
-  private var	_bezPathCache : UIBezierPath?
+  fileprivate var _edges : [FBBezierCurve]
+  fileprivate var _overlaps : [FBContourOverlap]
+  fileprivate var _bounds : CGRect
+  fileprivate var _boundingRect : CGRect
+  fileprivate var _inside : FBContourInside
+  fileprivate var	_bezPathCache : UIBezierPath?
 
 
   //@property FBContourInside inside;
@@ -62,10 +62,10 @@ class FBBezierContour {
     self._overlaps = []
     self._bounds = CGRect.null
     self._boundingRect = CGRect.null
-    self._inside = .Filled
+    self._inside = .filled
   }
 
-  class func bezierContourWithCurve(curve: FBBezierCurve) -> FBBezierContour {
+  class func bezierContourWithCurve(_ curve: FBBezierCurve) -> FBBezierContour {
     let result = FBBezierContour()
     result.addCurve(curve)
     return result
@@ -84,7 +84,7 @@ class FBBezierContour {
 
   // 72
   //- (void) addCurve:(FBBezierCurve *)curve
-  func addCurve(curve: FBBezierCurve?) {
+  func addCurve(_ curve: FBBezierCurve?) {
     // Add the curve by wrapping it in an edge
     if let curve = curve {
       curve.contour = self;
@@ -99,7 +99,7 @@ class FBBezierContour {
 
   // 86
   //- (void) addCurveFrom:(FBEdgeCrossing *)startCrossing to:(FBEdgeCrossing *)endCrossing
-  func addCurveFrom(startCrossing: FBEdgeCrossing?, to endCrossing: FBEdgeCrossing?) {
+  func addCurveFrom(_ startCrossing: FBEdgeCrossing?, to endCrossing: FBEdgeCrossing?) {
     // First construct the curve that we're going to add,
     // by seeing which crossing is nil.
     // If the crossing isn't given go to the end of the edge on that side.
@@ -111,7 +111,7 @@ class FBBezierContour {
     } else if endCrossing == nil, let startCrossing = startCrossing {
       // From startCrossing to end
       curve = startCrossing.rightCurve
-    } else if let startCrossing = startCrossing, endCrossing = endCrossing {
+    } else if let startCrossing = startCrossing, let endCrossing = endCrossing {
       // From startCrossing to endCrossing
       curve = startCrossing.curve?.subcurveWithRange(FBRange(minimum: startCrossing.parameter, maximum: endCrossing.parameter))
     }
@@ -124,7 +124,7 @@ class FBBezierContour {
 
   // 104
   //- (void) addReverseCurve:(FBBezierCurve *)curve
-  func addReverseCurve(curve: FBBezierCurve?) {
+  func addReverseCurve(_ curve: FBBezierCurve?) {
     // Just reverse the points on the curve.
     // Need to do this to ensure the end point from one edge
     // matches the start on the next edge.
@@ -136,7 +136,7 @@ class FBBezierContour {
 
   // 114
   //- (void) addReverseCurveFrom:(FBEdgeCrossing *)startCrossing to:(FBEdgeCrossing *)endCrossing
-  func addReverseCurveFrom(startCrossing: FBEdgeCrossing?, to endCrossing: FBEdgeCrossing?) {
+  func addReverseCurveFrom(_ startCrossing: FBEdgeCrossing?, to endCrossing: FBEdgeCrossing?) {
     // First construct the curve that we're going to add,
     // by seeing which crossing is nil.
     // If the crossing isn't given go to the end of the edge on that side.
@@ -148,7 +148,7 @@ class FBBezierContour {
     } else if endCrossing == nil, let startCrossing = startCrossing {
       // From startCrossing to end
       curve = startCrossing.rightCurve
-    } else if let startCrossing = startCrossing, endCrossing = endCrossing {
+    } else if let startCrossing = startCrossing, let endCrossing = endCrossing {
       // From startCrossing to endCrossing
       curve = startCrossing.curve?.subcurveWithRange(FBRange(minimum: startCrossing.parameter, maximum: endCrossing.parameter))
     }
@@ -163,7 +163,7 @@ class FBBezierContour {
   //- (NSRect) bounds
   var bounds : CGRect {
     // Cache the bounds to save time
-    if !CGRectEqualToRect(_bounds, CGRect.null) {
+    if !_bounds.equalTo(CGRect.null) {
       return _bounds
     }
 
@@ -175,12 +175,12 @@ class FBBezierContour {
     var totalBounds = CGRect.zero
     for edge in _edges {
       let edgeBounds : CGRect = edge.bounds
-      if CGRectEqualToRect(totalBounds, CGRect.zero) {
+      if totalBounds.equalTo(CGRect.zero) {
         totalBounds = edgeBounds
       } else {
         // This was:
         //   totalBounds = FBUnionRect(totalBounds, bounds)
-        totalBounds = CGRectUnion(totalBounds, edgeBounds)
+        totalBounds = totalBounds.union(edgeBounds)
       }
     }
 
@@ -194,7 +194,7 @@ class FBBezierContour {
   //- (NSRect) boundingRect
   var boundingRect : CGRect {
     // Cache the boundingRect to save time
-    if !CGRectEqualToRect(_boundingRect, CGRect.null) {
+    if !_boundingRect.equalTo(CGRect.null) {
       return _boundingRect
     }
 
@@ -206,12 +206,12 @@ class FBBezierContour {
     var totalBounds = CGRect.zero
     for edge in _edges {
       let edgeBounds : CGRect = edge.boundingRect
-      if CGRectEqualToRect(totalBounds, CGRect.zero) {
+      if totalBounds.equalTo(CGRect.zero) {
         totalBounds = edgeBounds
       } else {
         // This was:
         //   totalBounds = FBUnionRect(totalBounds, bounds)
-        totalBounds = CGRectUnion(totalBounds, edgeBounds)
+        totalBounds = totalBounds.union(edgeBounds)
       }
     }
 
@@ -233,9 +233,9 @@ class FBBezierContour {
 
   // 189
   //- (BOOL) containsPoint:(NSPoint)testPoint
-  func containsPoint(testPoint: CGPoint) -> Bool {
+  func containsPoint(_ testPoint: CGPoint) -> Bool {
 
-    if !CGRectContainsPoint(boundingRect, testPoint) || !CGRectContainsPoint(bounds, testPoint) {
+    if !boundingRect.contains(testPoint) || !bounds.contains(testPoint) {
       return false
     }
 
@@ -244,7 +244,7 @@ class FBBezierContour {
     // Based on the even/odd rule, if it's an odd number, we're inside
     // the graph, if even, outside.
 
-    let externalXPt = testPoint.x > CGRectGetMinX(bounds) ? CGRectGetMinX(bounds) - 10 : CGRectGetMaxX(bounds) + 10
+    let externalXPt = testPoint.x > bounds.minX ? bounds.minX - 10 : bounds.maxX + 10
     let lineEndPoint = CGPoint(x: externalXPt, y: testPoint.y)
     /* just move us outside the bounds of the graph */
     let testCurve = FBBezierCurve.bezierCurveWithLineStartPoint(testPoint, endPoint: lineEndPoint)
@@ -257,7 +257,7 @@ class FBBezierContour {
 
   // 204
   //- (NSUInteger) numberOfIntersectionsWithRay:(FBBezierCurve *)testEdge
-  func numberOfIntersectionsWithRay(testEdge: FBBezierCurve) -> Int {
+  func numberOfIntersectionsWithRay(_ testEdge: FBBezierCurve) -> Int {
     var count = 0
     intersectionsWithRay(testEdge, withBlock: {
       (intersection: FBBezierIntersection)-> Void in
@@ -269,7 +269,7 @@ class FBBezierContour {
 
   // 213
   //- (void) intersectionsWithRay:(FBBezierCurve *)testEdge withBlock:(void (^)(FBBezierIntersection *intersection))block
-  func intersectionsWithRay(testEdge: FBBezierCurve, withBlock block:(intersection: FBBezierIntersection) -> Void) {
+  func intersectionsWithRay(_ testEdge: FBBezierCurve, withBlock block:@escaping (_ intersection: FBBezierIntersection) -> Void) {
 
     var firstIntersection : FBBezierIntersection?
     var previousIntersection : FBBezierIntersection?
@@ -301,7 +301,7 @@ class FBBezierContour {
           }
         }
 
-        block(intersection: intersection)
+        block(intersection)
         if firstIntersection == nil {
           firstIntersection = intersection
         }
@@ -311,7 +311,7 @@ class FBBezierContour {
 
       if let intersectRange = intersectRange {
         if testEdge.crossesEdge(edge, atIntersectRange:intersectRange) {
-          block(intersection: intersectRange.middleIntersection)
+          block(intersectRange.middleIntersection)
         }
       }
     }
@@ -320,7 +320,7 @@ class FBBezierContour {
 
   // 251
   //- (FBBezierCurve *) startEdge
-  private var startEdge : FBBezierCurve? {
+  fileprivate var startEdge : FBBezierCurve? {
     // When marking we need to start at a point that is
     // clearly either inside or outside the other graph,
     // otherwise we could mark the crossings exactly opposite
@@ -400,7 +400,7 @@ class FBBezierContour {
 
   // 315
   //- (void) markCrossingsAsEntryOrExitWithContour:(FBBezierContour *)otherContour markInside:(BOOL)markInside
-  func markCrossingsAsEntryOrExitWithContour(otherContour: FBBezierContour, markInside: Bool) {
+  func markCrossingsAsEntryOrExitWithContour(_ otherContour: FBBezierContour, markInside: Bool) {
     // Go through and mark all the crossings with the given
     // contour as "entry" or "exit".
     // This determines what part of ths contour is output.
@@ -436,7 +436,8 @@ class FBBezierContour {
 
   // 347
   //- (BOOL) markCrossingsOnEdge:(FBBezierCurve *)edge startParameter:(CGFloat)startParameter stopParameter:(CGFloat)stopParameter otherContours:(NSArray *)otherContours isEntry:(BOOL)startIsEntry
-  func markCrossingsOnEdge(edge: FBBezierCurve, startParameter: Double, stopParameter: Double, otherContours: [FBBezierContour] , startIsEntry: Bool) -> Bool {
+  @discardableResult
+  func markCrossingsOnEdge(_ edge: FBBezierCurve, startParameter: Double, stopParameter: Double, otherContours: [FBBezierContour] , startIsEntry: Bool) -> Bool {
 
     var isEntry = startIsEntry
 
@@ -473,7 +474,7 @@ class FBBezierContour {
 
   // 363
   //- (BOOL) contourAndSelfIntersectingContoursContainPoint:(NSPoint)point
-  private func contourAndSelfIntersectingContoursContainPoint(point: CGPoint) -> Bool {
+  fileprivate func contourAndSelfIntersectingContoursContainPoint(_ point: CGPoint) -> Bool {
     var containerCount = 0
     if containsPoint(point) {
       containerCount += 1
@@ -498,19 +499,19 @@ class FBBezierContour {
 
       for edge in self.edges {
         if firstPoint {
-          path.moveToPoint(edge.endPoint1)
+          path.move(to: edge.endPoint1)
           firstPoint = false
         }
 
         if edge.isStraightLine {
-          path.addLineToPoint(edge.endPoint2)
+          path.addLine(to: edge.endPoint2)
         } else {
-          path.addCurveToPoint(edge.endPoint2, controlPoint1: edge.controlPoint1, controlPoint2: edge.controlPoint2)
+          path.addCurve(to: edge.endPoint2, controlPoint1: edge.controlPoint1, controlPoint2: edge.controlPoint2)
         }
       }
 
-      if !path.empty {
-        path.closePath()
+      if !path.isEmpty {
+        path.close()
       }
       path.usesEvenOddFillRule = true
 
@@ -570,7 +571,7 @@ class FBBezierContour {
       }
     }
 
-    return ( a >= 0 ) ? FBContourDirection.Clockwise : FBContourDirection.AntiClockwise
+    return ( a >= 0 ) ? FBContourDirection.clockwise : FBContourDirection.antiClockwise
   }
 
 
@@ -579,7 +580,7 @@ class FBBezierContour {
   var contourMadeClockwiseIfNecessary : FBBezierContour {
     let dir = self.direction
 
-    if dir == FBContourDirection.Clockwise {
+    if dir == FBContourDirection.clockwise {
       return self
     }
 
@@ -589,7 +590,7 @@ class FBBezierContour {
 
   // 459
   //- (BOOL) crossesOwnContour:(FBBezierContour *)contour
-  func crossesOwnContour(contour: FBBezierContour) -> Bool {
+  func crossesOwnContour(_ contour: FBBezierContour) -> Bool {
     for edge in _edges {
       var intersects = false
 
@@ -597,7 +598,7 @@ class FBBezierContour {
         (crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool) in
 
         // Only want the self intersecting crossings
-        if crossing.isSelfCrossing, let ccpart = crossing.counterpart, intersectingEdge = ccpart.edge {
+        if crossing.isSelfCrossing, let ccpart = crossing.counterpart, let intersectingEdge = ccpart.edge {
           if intersectingEdge.contour === contour {
             intersects = true
             return (true, true)
@@ -647,7 +648,7 @@ class FBBezierContour {
 
   // 499
   //- (void) addSelfIntersectingContoursToArray:(NSMutableArray *)contours originalContour:(FBBezierContour *)originalContour
-  private func addSelfIntersectingContoursToArray(inout contours: [FBBezierContour], originalContour: FBBezierContour) {
+  fileprivate func addSelfIntersectingContoursToArray(_ contours: inout [FBBezierContour], originalContour: FBBezierContour) {
     for edge in _edges {
 
       edge.selfIntersectingEdgesWithBlock() {
@@ -666,7 +667,7 @@ class FBBezierContour {
 
   // 511
   //- (void) addOverlap:(FBContourOverlap *)overlap
-  func addOverlap(overlap: FBContourOverlap) {
+  func addOverlap(_ overlap: FBContourOverlap) {
     if _overlaps.count == 0 {
       return
     }
@@ -688,7 +689,7 @@ class FBBezierContour {
 
   // 527
   //- (BOOL) isEquivalent:(FBBezierContour *)other
-  func isEquivalent(other: FBBezierContour) -> Bool {
+  func isEquivalent(_ other: FBBezierContour) -> Bool {
     if _overlaps.count == 0 {
       return false
     }
@@ -703,7 +704,7 @@ class FBBezierContour {
 
   // 539
   //- (void) forEachEdgeOverlapDo:(void (^)(FBEdgeOverlap *overlap))block
-  private func forEachEdgeOverlapDo(block:(overlap: FBEdgeOverlap) -> Void) {
+  fileprivate func forEachEdgeOverlapDo(_ block:(_ overlap: FBEdgeOverlap) -> Void) {
     if _overlaps.count == 0 {
       return
     }
@@ -712,7 +713,7 @@ class FBBezierContour {
       overlap.runsWithBlock() {
         (run: FBEdgeOverlapRun) -> Bool in
         for edgeOverlap in run.overlaps {
-          block(overlap: edgeOverlap)
+          block(edgeOverlap)
         }
         return false
       }
@@ -721,7 +722,7 @@ class FBBezierContour {
 
   // 552
   //- (BOOL) doesOverlapContainCrossing:(FBEdgeCrossing *)crossing
-  func doesOverlapContainCrossing(crossing: FBEdgeCrossing) -> Bool {
+  func doesOverlapContainCrossing(_ crossing: FBEdgeCrossing) -> Bool {
     if _overlaps.count == 0 {
       return false
     }
@@ -736,7 +737,7 @@ class FBBezierContour {
 
   // 564
   //- (BOOL) doesOverlapContainParameter:(CGFloat)parameter onEdge:(FBBezierCurve *)edge
-  func doesOverlapContainParameter(parameter: Double, onEdge edge: FBBezierCurve) -> Bool {
+  func doesOverlapContainParameter(_ parameter: Double, onEdge edge: FBBezierCurve) -> Bool {
     if _overlaps.count > 0 {
       for overlap in _overlaps {
         if overlap.doesContainParameter(parameter, onEdge:edge) {
@@ -749,7 +750,7 @@ class FBBezierContour {
 
   // 584
   //- (FBCurveLocation *) closestLocationToPoint:(NSPoint)point
-  func closestLocationToPoint(point: CGPoint) -> FBCurveLocation? {
+  func closestLocationToPoint(_ point: CGPoint) -> FBCurveLocation? {
     var closestEdge : FBBezierCurve? = nil
     var location = FBBezierCurveLocation(parameter: 0.0, distance: 0.0)
 
@@ -778,7 +779,7 @@ class FBBezierContour {
   /// This allows the internal state of a contour to be
   /// rapidly visualized so that bugs with boolean ops
   /// are easier to spot at a glance.
-  func debugPathForIntersectionType(itersectionType: Int) -> UIBezierPath {
+  func debugPathForIntersectionType(_ itersectionType: Int) -> UIBezierPath {
 
     let path : UIBezierPath = UIBezierPath()
 
@@ -797,9 +798,9 @@ class FBBezierContour {
           }
         }
         if crossing.isEntry {
-          path.appendPath(UIBezierPath.circleAtPoint(crossing.location))
+          path.append(UIBezierPath.circleAtPoint(crossing.location))
         } else {
-          path.appendPath(UIBezierPath.rectAtPoint(crossing.location))
+          path.append(UIBezierPath.rectAtPoint(crossing.location))
         }
 
         return (false, false)
@@ -809,17 +810,17 @@ class FBBezierContour {
     // Add the start point and direction for marking
     if let startEdge = self.startEdge {
       let startEdgeTangent = FBNormalizePoint(FBSubtractPoint(startEdge.controlPoint1, point2: startEdge.endPoint1));
-      path.appendPath(UIBezierPath.triangleAtPoint(startEdge.endPoint1, direction: startEdgeTangent))
+      path.append(UIBezierPath.triangleAtPoint(startEdge.endPoint1, direction: startEdgeTangent))
     }
 
     // Add the contour's entire path to make it easy
     // to see which one owns which crossings
     // (these can be colour-coded when drawing the paths)
-    path.appendPath(self.bezierPath)
+    path.append(self.bezierPath)
 
     // If this countour is flagged as "inside",
     // the debug path is shown dashed, otherwise solid
-    if self.inside == .Hole {
+    if self.inside == .hole {
       let dashes : [CGFloat] = [CGFloat(2), CGFloat(3)]
       path.setLineDash(dashes, count: 2, phase: 0)
     }

--- a/Swift VectorBoolean/VectorBoolean/FBBezierCurve.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierCurve.swift
@@ -58,7 +58,7 @@ struct FBNormalizedLine {
 
   // 53
   //static FBNormalizedLine FBNormalizedLineOffset(FBNormalizedLine line, CGFloat offset)
-  func copyWithOffset(offset: Double) -> FBNormalizedLine
+  func copyWithOffset(_ offset: Double) -> FBNormalizedLine
   {
     return FBNormalizedLine(
       a: self.a,
@@ -68,14 +68,14 @@ struct FBNormalizedLine {
 
   // 59
   // static CGFloat FBNormalizedLineDistanceFromPoint(FBNormalizedLine line, NSPoint point)
-  func distanceFromPoint(point: CGPoint) -> Double
+  func distanceFromPoint(_ point: CGPoint) -> Double
   {
     return a * Double(point.x) + b * Double(point.y) + c;
   }
 
   // 64
   //static NSPoint FBNormalizedLineIntersection(FBNormalizedLine line1, FBNormalizedLine line2)
-  func intersectionWith(other: FBNormalizedLine) -> CGPoint
+  func intersectionWith(_ other: FBNormalizedLine) -> CGPoint
   {
     let denominator = (self.a * other.b) - (other.a * self.b)
 
@@ -91,7 +91,7 @@ struct FBNormalizedLine {
 // ========================================================
 
 
-func FBParameterOfPointOnLine(lineStart: CGPoint, lineEnd: CGPoint, point: CGPoint) -> Double {
+func FBParameterOfPointOnLine(_ lineStart: CGPoint, lineEnd: CGPoint, point: CGPoint) -> Double {
 
   // Note: its asumed you have already checked that point is colinear with the line (lineStart, lineEnd)
 
@@ -112,7 +112,7 @@ func FBParameterOfPointOnLine(lineStart: CGPoint, lineEnd: CGPoint, point: CGPoi
 // var intersectAt = CGPoint(x:0,y:0)
 // var boolGotit = FBLinesIntersect(p1,p2,p3,p4,&intersectAt)
 
-func FBLinesIntersect(line1Start: CGPoint, line1End: CGPoint, line2Start: CGPoint, line2End: CGPoint, inout outIntersect: CGPoint) -> Bool
+func FBLinesIntersect(_ line1Start: CGPoint, line1End: CGPoint, line2Start: CGPoint, line2End: CGPoint, outIntersect: inout CGPoint) -> Bool
 {
   let line1 = FBNormalizedLine(point1: line1Start, point2: line1End)
   let line2 = FBNormalizedLine(point1: line2Start, point2: line2End)
@@ -126,7 +126,7 @@ func FBLinesIntersect(line1Start: CGPoint, line1End: CGPoint, line2Start: CGPoin
 
 /// The three points are a counter-clockwise turn if the return value is greater than 0,
 ///  clockwise if less than 0, or colinear if 0.
-func CounterClockwiseTurn(point1: CGPoint, point2: CGPoint, point3: CGPoint) -> Double
+func CounterClockwiseTurn(_ point1: CGPoint, point2: CGPoint, point3: CGPoint) -> Double
 {
   // We're calculating the signed area of the triangle formed by the three points. Well,
   //  almost the area of the triangle -- we'd need to divide by 2. But since we only
@@ -143,7 +143,7 @@ func CounterClockwiseTurn(point1: CGPoint, point2: CGPoint, point3: CGPoint) -> 
 
 
 /// Calculate if and where the given line intersects the horizontal line at y.
-func LineIntersectsHorizontalLine(startPoint: CGPoint, endPoint: CGPoint, y: Double, inout intersectPoint: CGPoint) -> Bool {
+func LineIntersectsHorizontalLine(_ startPoint: CGPoint, endPoint: CGPoint, y: Double, intersectPoint: inout CGPoint) -> Bool {
   // Do a quick test to see if y even falls on the startPoint,endPoint line
   let minY = Double(min(startPoint.y, endPoint.y))
   let maxY = Double(max(startPoint.y, endPoint.y))
@@ -167,7 +167,7 @@ func LineIntersectsHorizontalLine(startPoint: CGPoint, endPoint: CGPoint, y: Dou
 
 // 134
 /// Calculate a point on the bezier curve passed in, specifically the point at parameter.
-func BezierWithPoints(degree: Int, bezierPoints: [CGPoint], parameter: Double, withCurves: Bool) -> (point: CGPoint, leftCurve: [CGPoint]?, rightCurve: [CGPoint]?) {
+func BezierWithPoints(_ degree: Int, bezierPoints: [CGPoint], parameter: Double, withCurves: Bool) -> (point: CGPoint, leftCurve: [CGPoint]?, rightCurve: [CGPoint]?) {
 
   //  We're using De Casteljau's algorithm, which not only calculates the point at parameter
   //  in a numerically stable way, it also computes the two resulting bezier curves that
@@ -186,8 +186,8 @@ func BezierWithPoints(degree: Int, bezierPoints: [CGPoint], parameter: Double, w
     points.append(bezierPoints[i])
   }
 
-  var leftArray = [CGPoint](count: degree+1, repeatedValue: CGPointZero)
-  var rightArray = [CGPoint](count: degree+1, repeatedValue: CGPointZero)
+  var leftArray = [CGPoint](repeating: CGPoint.zero, count: degree+1)
+  var rightArray = [CGPoint](repeating: CGPoint.zero, count: degree+1)
 
   // If the caller is asking for the resulting bezier curves, start filling those in
   if withCurves {
@@ -213,7 +213,7 @@ func BezierWithPoints(degree: Int, bezierPoints: [CGPoint], parameter: Double, w
 }
 
 // 174
-func FBComputeCubicFirstDerivativeRoots(a: Double, b: Double, c: Double, d: Double) -> [Double]
+func FBComputeCubicFirstDerivativeRoots(_ a: Double, b: Double, c: Double, d: Double) -> [Double]
 {
   // See http://processingjs.nihongoresources.com/bezierinfo/#bounds for where the formulas come from
 
@@ -294,7 +294,7 @@ let FBLegendreGaussWeightValues : [[Double]] = [
   [0.1279381953467521593204025975865079089999,0.1279381953467521593204025975865079089999,0.1258374563468283025002847352880053222179,0.1258374563468283025002847352880053222179,0.1216704729278033914052770114722079597414,0.1216704729278033914052770114722079597414,0.1155056680537255991980671865348995197564,0.1155056680537255991980671865348995197564,0.1074442701159656343712356374453520402312,0.1074442701159656343712356374453520402312,0.0976186521041138843823858906034729443491,0.0976186521041138843823858906034729443491,0.0861901615319532743431096832864568568766,0.0861901615319532743431096832864568568766,0.0733464814110802998392557583429152145982,0.0733464814110802998392557583429152145982,0.0592985849154367833380163688161701429635,0.0592985849154367833380163688161701429635,0.0442774388174198077483545432642131345347,0.0442774388174198077483545432642131345347,0.0285313886289336633705904233693217975087,0.0285313886289336633705904233693217975087,0.0123412297999872001830201639904771582223,0.0123412297999872001830201639904771582223]
 ]
 
-func FBGaussQuadratureBaseForCubic(t: Double, p1: Double, p2: Double, p3: Double, p4: Double) -> Double
+func FBGaussQuadratureBaseForCubic(_ t: Double, p1: Double, p2: Double, p3: Double, p4: Double) -> Double
 {
   let t1 = (-3.0 * p1) + (9.0 * p2) - (9.0 * p3) + (3.0 * p4)
   let t2 = t * t1 + 6.0 * p1 - 12.0 * p2 + 6.0 * p3
@@ -303,7 +303,7 @@ func FBGaussQuadratureBaseForCubic(t: Double, p1: Double, p2: Double, p3: Double
   //return t * (t * (-3 * p1 + 9 * p2 - 9 * p3 + 3 * p4) + 6 * p1 + 12 * p2 + 3 * p3) - 3 * p1 + 3 * p2
 }
 
-func FBGaussQuadratureFOfTForCubic(t: Double, p1: CGPoint, p2: CGPoint, p3: CGPoint, p4: CGPoint) -> Double
+func FBGaussQuadratureFOfTForCubic(_ t: Double, p1: CGPoint, p2: CGPoint, p3: CGPoint, p4: CGPoint) -> Double
 {
   let baseX = FBGaussQuadratureBaseForCubic(t,
     p1: Double(p1.x),
@@ -319,7 +319,7 @@ func FBGaussQuadratureFOfTForCubic(t: Double, p1: CGPoint, p2: CGPoint, p3: CGPo
   return sqrt(baseX * baseX + baseY * baseY)
 }
 
-func FBGaussQuadratureComputeCurveLengthForCubic(z: Double, steps: Int, p1: CGPoint, p2: CGPoint, p3: CGPoint, p4: CGPoint) -> Double
+func FBGaussQuadratureComputeCurveLengthForCubic(_ z: Double, steps: Int, p1: CGPoint, p2: CGPoint, p3: CGPoint, p4: CGPoint) -> Double
 {
   let z2 = Double(z / 2.0)
   var sum : Double = 0.0
@@ -330,7 +330,7 @@ func FBGaussQuadratureComputeCurveLengthForCubic(z: Double, steps: Int, p1: CGPo
   return z2 * sum
 }
 
-func FBSign(value: CGFloat) -> Int
+func FBSign(_ value: CGFloat) -> Int
 {
   if value < 0.0 {
     return -1
@@ -339,7 +339,7 @@ func FBSign(value: CGFloat) -> Int
   }
 }
 
-func FBCountBezierCrossings(bezierPoints: [CGPoint], degree: Int) -> Int {
+func FBCountBezierCrossings(_ bezierPoints: [CGPoint], degree: Int) -> Int {
 
   var count : Int = 0
   var sign = FBSign(bezierPoints[0].y)
@@ -362,7 +362,7 @@ let FBFindBezierRootsMaximumDepth = 64
 // FBIsControlPolygonFlatEnough Usage:
 // var intersectAt = CGPoint(x:0,y:0)
 // var boolGotit = FBIsControlPolygonFlatEnough(points,degree,&intersectAt)
-func FBIsControlPolygonFlatEnough(bezierPoints: [CGPoint], degree: Int, inout intersectionPoint: CGPoint) -> Bool {
+func FBIsControlPolygonFlatEnough(_ bezierPoints: [CGPoint], degree: Int, intersectionPoint: inout CGPoint) -> Bool {
 
   // 2^-63
   let FBFindBezierRootsErrorThreshold = CGFloat(ldexpf(Float(1.0), Int32(-1 * (FBFindBezierRootsMaximumDepth - 1))))
@@ -400,7 +400,7 @@ func FBIsControlPolygonFlatEnough(bezierPoints: [CGPoint], degree: Int, inout in
 }
 
 // 330
-func FBFindBezierRootsWithDepth(bezierPoints: [CGPoint], degree: Int, depth: Int, perform: (root: Double) -> Void) {
+func FBFindBezierRootsWithDepth(_ bezierPoints: [CGPoint], degree: Int, depth: Int, perform: (_ root: Double) -> Void) {
 
   let crossingCount = FBCountBezierCrossings(bezierPoints, degree: degree)
   if crossingCount == 0 {
@@ -409,12 +409,12 @@ func FBFindBezierRootsWithDepth(bezierPoints: [CGPoint], degree: Int, depth: Int
   else if crossingCount == 1 {
     if depth >= FBFindBezierRootsMaximumDepth {
       let root = Double(bezierPoints[0].x + bezierPoints[degree].x) / 2.0
-      perform(root: root)
+      perform(root)
       return
     }
-    var intersectionPoint = CGPointZero
+    var intersectionPoint = CGPoint.zero
     if FBIsControlPolygonFlatEnough(bezierPoints, degree: degree, intersectionPoint: &intersectionPoint) {
-      perform(root: Double(intersectionPoint.x))
+      perform(Double(intersectionPoint.x))
       return
     }
   }
@@ -426,7 +426,7 @@ func FBFindBezierRootsWithDepth(bezierPoints: [CGPoint], degree: Int, depth: Int
 }
 
 // 356
-func FBFindBezierRoots(bezierPoints: [CGPoint], degree: Int, perform: (root: Double) -> Void) {
+func FBFindBezierRoots(_ bezierPoints: [CGPoint], degree: Int, perform: (_ root: Double) -> Void) {
 
   FBFindBezierRootsWithDepth(bezierPoints, degree: degree, depth: 0, perform: perform)
 }
@@ -437,14 +437,14 @@ func FBFindBezierRoots(bezierPoints: [CGPoint], degree: Int, perform: (root: Dou
 // ========================================================
 
 // 366
-func FBConvexHullDoPointsTurnWrongDirection(point1: CGPoint, point2: CGPoint, point3: CGPoint) -> Bool {
+func FBConvexHullDoPointsTurnWrongDirection(_ point1: CGPoint, point2: CGPoint, point3: CGPoint) -> Bool {
 
   let area = CounterClockwiseTurn(point1, point2: point2, point3: point3)
   return FBAreValuesClose(area, value2: 0.0) || area < 0.0
 }
 
 // 372
-func FBConvexHullBuildFromPoints(inPoints: [CGPoint]) -> (hull: [CGPoint], hullLength: Int) {
+func FBConvexHullBuildFromPoints(_ inPoints: [CGPoint]) -> (hull: [CGPoint], hullLength: Int) {
 
   // Compute the convex hull for this bezier curve. The convex hull is made up of the end and control points.
   //  The hard part is determine the order they go in, and if any are inside or colinear with the convex hull.
@@ -476,7 +476,7 @@ func FBConvexHullBuildFromPoints(inPoints: [CGPoint]) -> (hull: [CGPoint], hullL
 
   // Create the results
   var filledInIx = 0
-  var results = [CGPoint](count: 8, repeatedValue: CGPointZero)
+  var results = [CGPoint](repeating: CGPoint.zero, count: 8)
 
   // Build lower hull
   for i in 0 ..< numberOfPoints {
@@ -489,7 +489,7 @@ func FBConvexHullBuildFromPoints(inPoints: [CGPoint]) -> (hull: [CGPoint], hullL
 
   // Build upper hull
   let thresholdIndex = filledInIx + 1
-  for i in (0 ... numberOfPoints - 2).reverse() {
+  for i in (0 ... numberOfPoints - 2).reversed() {
     while filledInIx >= thresholdIndex && FBConvexHullDoPointsTurnWrongDirection(results[filledInIx - 2], point2: results[filledInIx - 1], point3: points[i]) {
       filledInIx -= 1
     }
@@ -508,7 +508,7 @@ func ILLUSTRATE_CALL_TO_FBConvexHullBuildFromPoints() {
   //  NSPoint convexHull[8] = {};
   //  FBConvexHullBuildFromPoints(distanceBezierPoints, convexHull, &convexHullLength);
 
-  let distanceBezierPoints = [CGPoint](count: 4, repeatedValue: CGPointZero)
+  let distanceBezierPoints = [CGPoint](repeating: CGPoint.zero, count: 4)
 
   let (_, convexHullLength) = FBConvexHullBuildFromPoints(distanceBezierPoints)
 
@@ -543,7 +543,7 @@ class FBBezierCurveData {
   var isStraightLine : Bool		// GPC: flag when curve came from a straight line segment
 
   var length : Double?         // cached value
-  private var _bounds : CGRect? // cached value
+  fileprivate var _bounds : CGRect? // cached value
   var _isPoint : Bool?          // cached value
   var _boundingRect : CGRect?   // cached value
 
@@ -700,7 +700,7 @@ class FBBezierCurveData {
   // Becomes:
   // let someLength = curve_data.getLengthAtParameter(CGFloat parameter)
   //
-  func getLengthAtParameter(parameter: Double) -> Double {
+  func getLengthAtParameter(_ parameter: Double) -> Double {
 
     // Use the cached value if at all possible
     if parameter == 1.0 && length != nil && length != FBBezierCurveDataInvalidLength {
@@ -741,7 +741,7 @@ class FBBezierCurveData {
   // Becomes:
   // let (point,left,right) = curve_data.pointAtParameter(param_float)
   //
-  func pointAtParameter(parameter: Double) -> (point: CGPoint, leftCurve: FBBezierCurveData?, rightCurve: FBBezierCurveData?) {
+  func pointAtParameter(_ parameter: Double) -> (point: CGPoint, leftCurve: FBBezierCurveData?, rightCurve: FBBezierCurveData?) {
 
     // This method is a simple wrapper around the BezierWithPoints() helper function. It computes the 2D point at the given parameter,
     //  and (optionally) the resulting curves that splitting at the parameter would create.
@@ -769,7 +769,7 @@ class FBBezierCurveData {
   // Becomes:
   // let new_curve_data = curve_data.subcurveWithRange(range)
   //
-  func subcurveWithRange(range: FBRange) -> FBBezierCurveData
+  func subcurveWithRange(_ range: FBRange) -> FBBezierCurveData
   {
     // Return a bezier curve representing the parameter range specified. We do this by splitting
     //  twice: once on the minimum, the splitting the result of that on the maximum.
@@ -847,7 +847,7 @@ class FBBezierCurveData {
   // Becomes:
   // let new_range = curve_data.clipWithFatLine(fatline, bounds)
   //
-  func clipWithFatLine(fatLine: FBNormalizedLine, bounds: FBRange) -> FBRange
+  func clipWithFatLine(_ fatLine: FBNormalizedLine, bounds: FBRange) -> FBRange
   {
     // This method computes the range of self that could possibly intersect with
     // the fat line passed in (and thus with the curve enclosed by the fat line).
@@ -937,7 +937,7 @@ class FBBezierCurveData {
 
   // 819
   //static void FBBezierCurveDataConvertSelfAndPoint(FBBezierCurveData me, NSPoint point, NSPoint *bezierPoints)
-  func convertSelfAndPoint(point: CGPoint) -> [CGPoint]
+  func convertSelfAndPoint(_ point: CGPoint) -> [CGPoint]
   {
     var selfPoints: [CGPoint] = [endPoint1, controlPoint1, controlPoint2, endPoint2]
 
@@ -976,7 +976,7 @@ class FBBezierCurveData {
     ]
 
     // create our output array
-    var bezierPoints = [CGPoint](count: 6, repeatedValue: CGPointZero)
+    var bezierPoints = [CGPoint](repeating: CGPoint.zero, count: 6)
 
     // Set the x values of the bezier points
     for i in 0 ..< 6 {
@@ -1000,7 +1000,7 @@ class FBBezierCurveData {
 
   // 864
   //static FBBezierCurveLocation FBBezierCurveDataClosestLocationToPoint(FBBezierCurveData me, NSPoint point)
-  func closestLocationToPoint(point: CGPoint) -> FBBezierCurveLocation
+  func closestLocationToPoint(_ point: CGPoint) -> FBBezierCurveLocation
   {
     let bezierPoints = convertSelfAndPoint(point)
 
@@ -1030,7 +1030,7 @@ class FBBezierCurveData {
 
   // 893
   //static BOOL FBBezierCurveDataIsEqualWithOptions(FBBezierCurveData me, FBBezierCurveData other, CGFloat threshold)
-  func isEqualWithOptions(other: FBBezierCurveData, threshold: Double) -> Bool
+  func isEqualWithOptions(_ other: FBBezierCurveData, threshold: Double) -> Bool
   {
     if isPoint() || other.isPoint() {
       return false
@@ -1060,7 +1060,7 @@ class FBBezierCurveData {
 // Becomes:
 // let (new_curve, success) = curve_data.bezierClipWithBezierCurve(curve, &originalCurve, &originalRange)
 //
-func bezierClipWithBezierCurve(me: FBBezierCurveData, curve: FBBezierCurveData, inout originalCurve: FBBezierCurveData, inout originalRange: FBRange) -> (clipped: FBBezierCurveData, intersects: Bool)
+func bezierClipWithBezierCurve(_ me: FBBezierCurveData, curve: FBBezierCurveData, originalCurve: inout FBBezierCurveData, originalRange: inout FBRange) -> (clipped: FBBezierCurveData, intersects: Bool)
 {
   // This method does the clipping of self. It removes the parts of self that we can determine don't intersect
   //  with curve. It'll return the clipped version of self, update originalRange which corresponds to the range
@@ -1141,15 +1141,15 @@ func bezierClipWithBezierCurve(me: FBBezierCurveData, curve: FBBezierCurveData, 
 // ========================================================
 // NOTE: Need to decide whether this needs to be static
 // ========================================================
-private func refineIntersectionsOverIterations(iterations: Int,
-  inout usRange: FBRange,
-  inout themRange: FBRange,
-  inout originalUs: FBBezierCurveData,
-  inout originalThem: FBBezierCurveData,
-  inout us: FBBezierCurveData,
-  inout them: FBBezierCurveData,
-  inout nonpointUs: FBBezierCurveData,
-  inout nonpointThem: FBBezierCurveData)
+private func refineIntersectionsOverIterations(_ iterations: Int,
+  usRange: inout FBRange,
+  themRange: inout FBRange,
+  originalUs: inout FBBezierCurveData,
+  originalThem: inout FBBezierCurveData,
+  us: inout FBBezierCurveData,
+  them: inout FBBezierCurveData,
+  nonpointUs: inout FBBezierCurveData,
+  nonpointThem: inout FBBezierCurveData)
 {
   for _ in 0..<iterations {
     var intersects = false
@@ -1190,7 +1190,7 @@ let (clippedCurve, intersects) = clipLineOriginalCurve(blah, blah, blah.....)
 - returns: **clippedCurve** - a curve clipped by another
 - returns: **intersects** - a success flag
 */
-private func clipLineOriginalCurve(originalCurve: FBBezierCurveData, curve: FBBezierCurveData, inout originalRange: FBRange, otherCurve: FBBezierCurveData) -> (clippedCurve: FBBezierCurveData, intersects: Bool)
+private func clipLineOriginalCurve(_ originalCurve: FBBezierCurveData, curve: FBBezierCurveData, originalRange: inout FBRange, otherCurve: FBBezierCurveData) -> (clippedCurve: FBBezierCurveData, intersects: Bool)
 {
   let themOnUs1 = FBParameterOfPointOnLine(curve.endPoint1, lineEnd: curve.endPoint2, point: otherCurve.endPoint1)
   let themOnUs2 = FBParameterOfPointOnLine(curve.endPoint1, lineEnd: curve.endPoint2, point: otherCurve.endPoint2)
@@ -1230,7 +1230,8 @@ BOOL overlaps = FBBezierCurveDataCheckLinesForOverlap(FBBezierCurveData me, FBRa
 let overlaps = checkLinesForOverlap(blah, blah, blah.....)
 
 */
-private func checkLinesForOverlap(me: FBBezierCurveData, inout usRange: FBRange, inout themRange: FBRange, originalUs: FBBezierCurveData, originalThem: FBBezierCurveData, inout us: FBBezierCurveData, inout them: FBBezierCurveData) -> Bool
+@discardableResult
+private func checkLinesForOverlap(_ me: FBBezierCurveData, usRange: inout FBRange, themRange: inout FBRange, originalUs: FBBezierCurveData, originalThem: FBBezierCurveData, us: inout FBBezierCurveData, them: inout FBBezierCurveData) -> Bool
 {
   // First see if its possible for them to overlap at all
   if !FBLineBoundsMightOverlap(us.bounds, bounds2: them.bounds) {
@@ -1269,7 +1270,7 @@ private func checkLinesForOverlap(me: FBBezierCurveData, inout usRange: FBRange,
 
 // 906
 //static BOOL FBBezierCurveDataAreCurvesEqual(FBBezierCurveData me, FBBezierCurveData other)
-private func curvesAreEqual(me: FBBezierCurveData, other: FBBezierCurveData) -> Bool
+private func curvesAreEqual(_ me: FBBezierCurveData, other: FBBezierCurveData) -> Bool
 {
   if me.isPoint() || other.isPoint() {
     return false
@@ -1295,7 +1296,7 @@ private func curvesAreEqual(me: FBBezierCurveData, other: FBBezierCurveData) -> 
 
 // 926
 //static BOOL FBBezierCurveDataIsEqual(FBBezierCurveData me, FBBezierCurveData other)
-private func dataIsEqual(me: FBBezierCurveData, other: FBBezierCurveData) -> Bool
+private func dataIsEqual(_ me: FBBezierCurveData, other: FBBezierCurveData) -> Bool
 {
   // LRT - fiddle with these
   let threshold = isRunningOn64BitDevice ? 1e-10 : 1e-2
@@ -1304,7 +1305,7 @@ private func dataIsEqual(me: FBBezierCurveData, other: FBBezierCurveData) -> Boo
 
 // 931
 //static FBBezierCurveData FBBezierCurveDataReversed(FBBezierCurveData me)
-private func reversed(me: FBBezierCurveData) -> FBBezierCurveData
+private func reversed(_ me: FBBezierCurveData) -> FBBezierCurveData
 {
   return FBBezierCurveData(endPoint1: me.endPoint2, controlPoint1: me.controlPoint2, controlPoint2: me.controlPoint1, endPoint2: me.endPoint1, isStraightLine: me.isStraightLine)
 }
@@ -1312,7 +1313,8 @@ private func reversed(me: FBBezierCurveData) -> FBBezierCurveData
 
 // 936
 // static BOOL FBBezierCurveDataCheckForOverlapRange(FBBezierCurveData me, FBBezierIntersectRange **intersectRange, FBRange *usRange, FBRange *themRange, FBBezierCurve* originalUs, FBBezierCurve* originalThem, FBBezierCurveData us, FBBezierCurveData them)
-private func checkForOverlapRange(me: FBBezierCurveData, inout intersectRange: FBBezierIntersectRange?, inout usRange: FBRange, inout themRange: FBRange, originalUs: FBBezierCurve, originalThem: FBBezierCurve, us: FBBezierCurveData, them: FBBezierCurveData) -> Bool
+@discardableResult
+private func checkForOverlapRange(_ me: FBBezierCurveData, intersectRange: inout FBBezierIntersectRange?, usRange: inout FBRange, themRange: inout FBRange, originalUs: FBBezierCurve, originalThem: FBBezierCurve, us: FBBezierCurveData, them: FBBezierCurveData) -> Bool
 {
   if curvesAreEqual(us, other: them) {
     // TODO: Is this range not being sent back up to the inout parameter ?
@@ -1330,7 +1332,7 @@ private func checkForOverlapRange(me: FBBezierCurveData, inout intersectRange: F
 
 // 952
 //static FBBezierCurveData FBBezierCurveDataFindPossibleOverlap(FBBezierCurveData me, FBBezierCurveData originalUs, FBBezierCurveData them, FBRange *possibleRange)
-private func findPossibleOverlap(me: FBBezierCurveData, originalUs: FBBezierCurveData, them: FBBezierCurveData, inout possibleRange: FBRange) -> FBBezierCurveData
+private func findPossibleOverlap(_ me: FBBezierCurveData, originalUs: FBBezierCurveData, them: FBBezierCurveData, possibleRange: inout FBRange) -> FBBezierCurveData
 {
   let themOnUs1 = originalUs.closestLocationToPoint(them.endPoint1)
   let themOnUs2 = originalUs.closestLocationToPoint(them.endPoint2)
@@ -1346,10 +1348,10 @@ private func findPossibleOverlap(me: FBBezierCurveData, originalUs: FBBezierCurv
 // 961
 //static BOOL FBBezierCurveDataCheckCurvesForOverlapRange(FBBezierCurveData me, FBBezierIntersectRange **intersectRange, FBRange *usRange, FBRange *themRange, FBBezierCurve* originalUs, FBBezierCurve* originalThem, FBBezierCurveData us, FBBezierCurveData them)
 private func checkCurvesForOverlapRange(
-  me: FBBezierCurveData,
-  inout intersectRange: FBBezierIntersectRange?,
-  inout usRange: FBRange,
-  inout themRange: FBRange,
+  _ me: FBBezierCurveData,
+  intersectRange: inout FBBezierIntersectRange?,
+  usRange: inout FBRange,
+  themRange: inout FBRange,
   originalUs: FBBezierCurve,
   originalThem: FBBezierCurve,
   us: FBBezierCurveData,
@@ -1385,14 +1387,14 @@ let FBBezierCurveDataInvalidLength = -1.0
 // 982
 //static void FBBezierCurveDataCheckNoIntersectionsForOverlapRange(FBBezierCurveData me, FBBezierIntersectRange **intersectRange, FBRange *usRange, FBRange *themRange, FBBezierCurve* originalUs, FBBezierCurve* originalThem, FBBezierCurveData us, FBBezierCurveData them, FBBezierCurveData nonpointUs, FBBezierCurveData nonpointThem)
 private func checkNoIntersectionsForOverlapRange(
-  me: FBBezierCurveData,
-  inout intersectRange: FBBezierIntersectRange?,
-  inout usRange: FBRange,
-  inout themRange: FBRange,
+  _ me: FBBezierCurveData,
+  intersectRange: inout FBBezierIntersectRange?,
+  usRange: inout FBRange,
+  themRange: inout FBRange,
   originalUs: FBBezierCurve,
   originalThem: FBBezierCurve,
-  inout us: FBBezierCurveData,
-  inout them: FBBezierCurveData,
+  us: inout FBBezierCurveData,
+  them: inout FBBezierCurveData,
   nonpointUs: FBBezierCurveData,
   nonpointThem: FBBezierCurveData
   )
@@ -1408,14 +1410,14 @@ private func checkNoIntersectionsForOverlapRange(
 //static BOOL FBBezierCurveDataCheckForStraightLineOverlap(FBBezierCurveData me, FBBezierIntersectRange **intersectRange, FBRange *usRange, FBRange *themRange, FBBezierCurve* originalUs, FBBezierCurve* originalThem, FBBezierCurveData us, FBBezierCurveData them, FBBezierCurveData nonpointUs, FBBezierCurveData nonpointThem)
 
 private func straightLineOverlap(
-  me: FBBezierCurveData,
-  inout intersectRange: FBBezierIntersectRange?,
-  inout usRange: FBRange,
-  inout themRange: FBRange,
+  _ me: FBBezierCurveData,
+  intersectRange: inout FBBezierIntersectRange?,
+  usRange: inout FBRange,
+  themRange: inout FBRange,
   originalUs: FBBezierCurve,
   originalThem: FBBezierCurve,
-  inout us: FBBezierCurveData,
-  inout them: FBBezierCurveData,
+  us: inout FBBezierCurveData,
+  them: inout FBBezierCurveData,
   nonpointUs: FBBezierCurveData,
   nonpointThem: FBBezierCurveData) -> Bool
 {
@@ -1434,7 +1436,7 @@ private func straightLineOverlap(
 
 // 1003
 //static CGFloat FBBezierCurveDataRefineParameter(FBBezierCurveData me, CGFloat parameter, NSPoint point)
-private func pfRefineParameter(me: FBBezierCurveData, parameter: Double, point: CGPoint) -> Double
+private func pfRefineParameter(_ me: FBBezierCurveData, parameter: Double, point: CGPoint) -> Double
 {
   // Use Newton's Method to refine our parameter. In general, that formula is:
   //
@@ -1497,7 +1499,7 @@ private func pfRefineParameter(me: FBBezierCurveData, parameter: Double, point: 
 
 // 1050
 //static FBBezierIntersectRange *FBBezierCurveDataMergeIntersectRange(FBBezierIntersectRange *intersectRange, FBBezierIntersectRange *otherIntersectRange)
-private func mergeIntersectRange(intersectRange: FBBezierIntersectRange?, otherIntersectRange: FBBezierIntersectRange?) -> FBBezierIntersectRange?
+private func mergeIntersectRange(_ intersectRange: FBBezierIntersectRange?, otherIntersectRange: FBBezierIntersectRange?) -> FBBezierIntersectRange?
 {
   if otherIntersectRange == nil {
     return intersectRange
@@ -1515,16 +1517,17 @@ private func mergeIntersectRange(intersectRange: FBBezierIntersectRange?, otherI
 
 // 1063
 //static BOOL FBBezierCurveDataIntersectionsWithStraightLines(FBBezierCurveData me, FBBezierCurveData curve, FBRange *usRange, FBRange *themRange, FBBezierCurve *originalUs, FBBezierCurve *originalThem, FBCurveIntersectionBlock outputBlock, BOOL *stop)
+@discardableResult
 private func intersectionsWithStraightLines(
-  me: FBBezierCurveData,
+  _ me: FBBezierCurveData,
   curve: FBBezierCurveData,
-  inout usRange: FBRange,
-  inout themRange: FBRange,
+  usRange: inout FBRange,
+  themRange: inout FBRange,
   originalUs: FBBezierCurve,
   originalThem: FBBezierCurve,
-  inout stop: Bool,
+  stop: inout Bool,
   // TODO: Need to see if there's a better way to define a block type in Swift
-  outputBlock: (intersect: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool)
+  outputBlock: (_ intersect: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool)
   //outputBlock: (FBBezierIntersection, Bool) -> Bool
   ) -> Bool
 {
@@ -1533,7 +1536,7 @@ private func intersectionsWithStraightLines(
   }
 
 
-  var intersectionPoint = CGPointZero
+  var intersectionPoint = CGPoint.zero
   let intersects = FBLinesIntersect(me.endPoint1, line1End: me.endPoint2, line2Start: curve.endPoint1, line2End: curve.endPoint2, outIntersect: &intersectionPoint)
   if !intersects {
     return false
@@ -1551,7 +1554,7 @@ private func intersectionsWithStraightLines(
 
   let intersect = FBBezierIntersection(curve1: originalUs, param1:meParam, curve2:originalThem, param2:curveParam)
 
-  let stopResults = outputBlock(intersect: intersect)
+  let stopResults = outputBlock(intersect)
   if stopResults.setStop {
     stop = stopResults.stopValue
   }
@@ -1567,16 +1570,16 @@ private func intersectionsWithStraightLines(
 // 1086
 //static void FBBezierCurveDataIntersectionsWithBezierCurve(FBBezierCurveData me, FBBezierCurveData curve, FBRange *usRange, FBRange *themRange, FBBezierCurve *originalUs, FBBezierCurve *originalThem, FBBezierIntersectRange **intersectRange, NSUInteger depth, FBCurveIntersectionBlock outputBlock, BOOL *stop)
 internal func pfIntersectionsWithBezierCurve(
-  me: FBBezierCurveData,
+  _ me: FBBezierCurveData,
   curve: FBBezierCurveData,
-  inout usRange: FBRange,
-  inout themRange: FBRange,
+  usRange: inout FBRange,
+  themRange: inout FBRange,
   originalUs: FBBezierCurve,
   originalThem: FBBezierCurve,
-  inout intersectRange: FBBezierIntersectRange?,
+  intersectRange: inout FBBezierIntersectRange?,
   depth: Int,
-  inout stop: Bool,
-  outputBlock: (intersect: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool))
+  stop: inout Bool,
+  outputBlock: (_ intersect: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool))
   //outputBlock: (FBBezierIntersection, Bool) -> (Bool))
 {
   // This is the main work loop.
@@ -1882,7 +1885,7 @@ internal func pfIntersectionsWithBezierCurve(
   // plus it allows us to do lazy calculations.
   let intersection = FBBezierIntersection(curve1: originalUs, param1: FBRangeAverage(usRange), curve2:originalThem, param2: FBRangeAverage(themRange))
 
-  let stopResults = outputBlock(intersect: intersection)
+  let stopResults = outputBlock(intersection)
   if stopResults.setStop {
     stop = stopResults.stopValue
   }
@@ -1914,9 +1917,9 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // MARK: edge extensions
 
-  private var _startShared = false
-  private var _contour: FBBezierContour?
-  private var _index: Int = 0
+  fileprivate var _startShared = false
+  fileprivate var _contour: FBBezierContour?
+  fileprivate var _index: Int = 0
   var crossings: [FBEdgeCrossing] = []
 
   // 89 of Edge extension
@@ -1970,7 +1973,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
   //var hasNonselfCrossings = false
 
   // MARK: standard class
-  private var _data : FBBezierCurveData
+  fileprivate var _data : FBBezierCurveData
 
   var data : FBBezierCurveData {
     get {
@@ -2065,7 +2068,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
   }
 
   // 1336
-  class func bezierCurvesFromBezierPath(path: UIBezierPath!) -> [FBBezierCurve] {
+  class func bezierCurvesFromBezierPath(_ path: UIBezierPath!) -> [FBBezierCurve] {
     // Helper method to easily convert a bezier path into an array of FBBezierCurves.
     // Very straight-forward, only lines are a special case.
 
@@ -2074,23 +2077,23 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
     let bezier = LRTBezierPathWrapper(path)
     var bezierCurves : [FBBezierCurve] = []
 
-    var previousPoint = CGPointZero
+    var previousPoint = CGPoint.zero
 
     for item in bezier.elements {
 
       switch item {
 
-      case let .Move(v):
+      case let .move(v):
         previousPoint = v
         startPoint = v
 
-      case let .Line(v):
+      case let .line(v):
         // Convert lines to bezier curves as well.
         // Just set control point to be in the line formed by the end points
         bezierCurves.append(FBBezierCurve(startPoint: previousPoint, endPoint: v))
         previousPoint = v
 
-      case .QuadCurve(let to, let cp):
+      case .quadCurve(let to, let cp):
         let ⅔ : CGFloat = 2.0 / 3.0
 
         // lastPoint + twoThirds * (via - lastPoint)
@@ -2101,19 +2104,19 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
         bezierCurves.append(FBBezierCurve(endPoint1: previousPoint, controlPoint1: cp1, controlPoint2: cp2, endPoint2: to))
         previousPoint = to
 
-      case .CubicCurve(let to, let v1, let v2):
+      case .cubicCurve(let to, let v1, let v2):
         bezierCurves.append(FBBezierCurve(endPoint1: previousPoint, controlPoint1: v1, controlPoint2: v2, endPoint2: to))
         previousPoint = to
 
-      case .Close:
+      case .close:
         // Create a line back to the start if required
         if let startPoint = startPoint {
-          if !CGPointEqualToPoint(previousPoint, startPoint) {
+          if !previousPoint.equalTo(startPoint) {
             bezierCurves.append(FBBezierCurve(startPoint: previousPoint, endPoint: startPoint))
           }
         }
         startPoint = nil
-        previousPoint = CGPointZero
+        previousPoint = CGPoint.zero
       }
     }
 
@@ -2121,19 +2124,19 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
   }
 
   // 1376
-  class func bezierCurveWithLineStartPoint(startPoint: CGPoint, endPoint: CGPoint) -> FBBezierCurve
+  class func bezierCurveWithLineStartPoint(_ startPoint: CGPoint, endPoint: CGPoint) -> FBBezierCurve
   {
     return FBBezierCurve(startPoint: startPoint, endPoint: endPoint)
   }
 
   // 1381
-  class func bezierCurveWithEndPoint1(endPoint1: CGPoint, controlPoint1: CGPoint, controlPoint2: CGPoint, endPoint2: CGPoint) -> FBBezierCurve
+  class func bezierCurveWithEndPoint1(_ endPoint1: CGPoint, controlPoint1: CGPoint, controlPoint2: CGPoint, endPoint2: CGPoint) -> FBBezierCurve
   {
     return FBBezierCurve(endPoint1: endPoint1, controlPoint1: controlPoint1, controlPoint2: controlPoint2, endPoint2: endPoint2)
   }
 
   // 1386
-  class func bezierCurveWithBezierCurveData(data: FBBezierCurveData) -> FBBezierCurve
+  class func bezierCurveWithBezierCurveData(_ data: FBBezierCurveData) -> FBBezierCurve
   {
     return FBBezierCurve(curveData: data)
   }
@@ -2155,7 +2158,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
 
   // 1438
-  func isEqual(object: AnyObject) -> Bool
+  func isEqual(_ object: AnyObject) -> Bool
   {
     if let other = object as? FBBezierCurve {
       return dataIsEqual(_data, other: other._data)
@@ -2165,7 +2168,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
   }
 
   // 1447
-  func doesHaveIntersectionsWithBezierCurve(curve: FBBezierCurve) -> Bool
+  func doesHaveIntersectionsWithBezierCurve(_ curve: FBBezierCurve) -> Bool
   {
     // (intersect: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool)
     var count = 0
@@ -2182,8 +2185,8 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1457
   //- (void) intersectionsWithBezierCurve:(FBBezierCurve *)curve overlapRange:(FBBezierIntersectRange **)intersectRange withBlock:(FBCurveIntersectionBlock)block
-  func intersectionsWithBezierCurve(curve: FBBezierCurve, inout overlapRange: FBBezierIntersectRange?,
-    withBlock block : (intersect: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool))
+  func intersectionsWithBezierCurve(_ curve: FBBezierCurve, overlapRange: inout FBBezierIntersectRange?,
+    withBlock block : (_ intersect: FBBezierIntersection) -> (setStop: Bool, stopValue:Bool))
   {
     // For performance reasons, do a quick bounds check to see if these even might intersect
     if !FBLineBoundsMightOverlap(_data.boundingRect, bounds2: curve._data.boundingRect) {
@@ -2202,13 +2205,13 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1473
   //- (FBBezierCurve *) subcurveWithRange:(FBRange)range
-  func subcurveWithRange(range: FBRange) -> FBBezierCurve {
+  func subcurveWithRange(_ range: FBRange) -> FBBezierCurve {
     return FBBezierCurve(curveData: _data.subcurveWithRange(range))
   }
 
   // 1478
   //- (void) splitSubcurvesWithRange:(FBRange)range left:(FBBezierCurve **)leftCurve middle:(FBBezierCurve **)middleCurve right:(FBBezierCurve **)rightCurve
-  func splitSubcurvesWithRange(range: FBRange, left: Bool, middle: Bool, right: Bool) -> (left: FBBezierCurve?, mid: FBBezierCurve?, right: FBBezierCurve?) {
+  func splitSubcurvesWithRange(_ range: FBRange, left: Bool, middle: Bool, right: Bool) -> (left: FBBezierCurve?, mid: FBBezierCurve?, right: FBBezierCurve?) {
     // Return a bezier curve representing the parameter range specified.
     // We do this by splitting twice:
     //   once on the minimum, then splitting the result of that on the maximum.
@@ -2280,7 +2283,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1521
   //- (NSPoint) pointAtParameter:(CGFloat)parameter leftBezierCurve:(FBBezierCurve **)leftBezierCurve rightBezierCurve:(FBBezierCurve **)rightBezierCurve
-  func pointAtParameter(parameter: Double) -> (point: CGPoint, leftBezierCurve: FBBezierCurve?, rightBezierCurve: FBBezierCurve?) {
+  func pointAtParameter(_ parameter: Double) -> (point: CGPoint, leftBezierCurve: FBBezierCurve?, rightBezierCurve: FBBezierCurve?) {
 
     var leftBezierCurve: FBBezierCurve?
     var rightBezierCurve: FBBezierCurve?
@@ -2297,7 +2300,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1535
   //- (CGFloat) refineParameter:(CGFloat)parameter forPoint:(NSPoint)point
-  private func refineParameter(parameter: Double, forPoint point: CGPoint) -> Double {
+  fileprivate func refineParameter(_ parameter: Double, forPoint point: CGPoint) -> Double {
     return pfRefineParameter(self.data, parameter: parameter, point: point)
   }
 
@@ -2309,7 +2312,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1545
   //- (CGFloat) lengthAtParameter:(CGFloat)parameter
-  func lengthAtParameter(parameter: Double) -> Double {
+  func lengthAtParameter(_ parameter: Double) -> Double {
     return _data.getLengthAtParameter(parameter)
   }
 
@@ -2322,7 +2325,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1555
   //- (FBBezierCurveLocation) closestLocationToPoint:(NSPoint)point
-  func closestLocationToPoint(point: CGPoint) -> FBBezierCurveLocation {
+  func closestLocationToPoint(_ point: CGPoint) -> FBBezierCurveLocation {
     return _data.closestLocationToPoint(point)
   }
 
@@ -2340,7 +2343,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1570
   //- (NSPoint) pointFromRightOffset:(CGFloat)offset
-  func pointFromRightOffset(offset: Double) -> CGPoint
+  func pointFromRightOffset(_ offset: Double) -> CGPoint
   {
     var offset = offset
     let len = length()
@@ -2351,7 +2354,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1578
   //- (NSPoint) pointFromLeftOffset:(CGFloat)offset
-  func pointFromLeftOffset(offset: Double) -> CGPoint
+  func pointFromLeftOffset(_ offset: Double) -> CGPoint
   {
     var offset = offset
     let len = length()
@@ -2362,14 +2365,14 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
 
   // 1586
   //- (NSPoint) tangentFromRightOffset:(CGFloat)offset
-  func tangentFromRightOffset(offset: Double) -> CGPoint
+  func tangentFromRightOffset(_ offset: Double) -> CGPoint
   {
     var offset = offset
     if _data.isStraightLine && !_data.isPoint() {
       return FBSubtractPoint(_data.endPoint1, point2: _data.endPoint2)
     }
 
-    if offset == 0.0 && !CGPointEqualToPoint(_data.controlPoint2, _data.endPoint2) {
+    if offset == 0.0 && !_data.controlPoint2.equalTo(_data.endPoint2) {
       return FBSubtractPoint(_data.controlPoint2, point2: _data.endPoint2)
     } else {
       let len = length()
@@ -2383,19 +2386,19 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
       }
     }
     
-    return CGPointZero  // nothing else worked!
+    return CGPoint.zero  // nothing else worked!
   }
 
   // 1607
   //- (NSPoint) tangentFromLeftOffset:(CGFloat)offset
-  func tangentFromLeftOffset(offset: Double) -> CGPoint
+  func tangentFromLeftOffset(_ offset: Double) -> CGPoint
   {
     var offset = offset
     if _data.isStraightLine && !_data.isPoint() {
       return FBSubtractPoint(_data.endPoint2, point2: _data.endPoint1)
     }
 
-    if offset == 0.0 && !CGPointEqualToPoint(_data.controlPoint1, _data.endPoint1) {
+    if offset == 0.0 && !_data.controlPoint1.equalTo(_data.endPoint1) {
       return FBSubtractPoint(_data.controlPoint1, point2: _data.endPoint1)
     } else {
       let len = length()
@@ -2409,7 +2412,7 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
       }
     }
 
-    return CGPointZero  // nothing else worked!
+    return CGPoint.zero  // nothing else worked!
   }
 
   // 1628
@@ -2417,8 +2420,8 @@ class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertible, Equ
   var bezierPath : UIBezierPath
   {
     let path = UIBezierPath()
-    path.moveToPoint(endPoint1)
-    path.addCurveToPoint(endPoint2, controlPoint1: controlPoint1, controlPoint2: controlPoint2)
+    path.move(to: endPoint1)
+    path.addCurve(to: endPoint2, controlPoint1: controlPoint1, controlPoint2: controlPoint2)
     return path
   }
 

--- a/Swift VectorBoolean/VectorBoolean/FBBezierCurve_Edge.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierCurve_Edge.swift
@@ -13,7 +13,7 @@ import UIKit
 
 // 18
 //static void FBFindEdge1TangentCurves(FBBezierCurve *edge, FBBezierIntersection *intersection, FBBezierCurve** leftCurve, FBBezierCurve **rightCurve)
-private func FBFindEdge1TangentCurves(edge: FBBezierCurve, intersection: FBBezierIntersection) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
+private func FBFindEdge1TangentCurves(_ edge: FBBezierCurve, intersection: FBBezierIntersection) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
 
   var leftCurve: FBBezierCurve, rightCurve: FBBezierCurve
 
@@ -33,7 +33,7 @@ private func FBFindEdge1TangentCurves(edge: FBBezierCurve, intersection: FBBezie
 
 // 32
 //static void FBFindEdge2TangentCurves(FBBezierCurve *edge, FBBezierIntersection *intersection, FBBezierCurve** leftCurve, FBBezierCurve **rightCurve)
-private func FBFindEdge2TangentCurves(edge: FBBezierCurve, intersection: FBBezierIntersection) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
+private func FBFindEdge2TangentCurves(_ edge: FBBezierCurve, intersection: FBBezierIntersection) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
 
   var leftCurve: FBBezierCurve, rightCurve: FBBezierCurve
 
@@ -53,13 +53,13 @@ private func FBFindEdge2TangentCurves(edge: FBBezierCurve, intersection: FBBezie
 
 // 46
 //static void FBComputeEdgeTangents(FBBezierCurve* leftCurve, FBBezierCurve *rightCurve, CGFloat offset, NSPoint edgeTangents[2])
-private func FBComputeEdgeTangents(leftCurve: FBBezierCurve, rightCurve: FBBezierCurve, offset: Double, inout edgeTangents: FBTangentPair) {
+private func FBComputeEdgeTangents(_ leftCurve: FBBezierCurve, rightCurve: FBBezierCurve, offset: Double, edgeTangents: inout FBTangentPair) {
   edgeTangents.left = leftCurve.tangentFromRightOffset(offset)
   edgeTangents.right = rightCurve.tangentFromLeftOffset(offset)
 }
 
 // 53
-private func FBComputeEdge1RangeTangentCurves(edge: FBBezierCurve, intersectRange: FBBezierIntersectRange) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
+private func FBComputeEdge1RangeTangentCurves(_ edge: FBBezierCurve, intersectRange: FBBezierIntersectRange) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
 
   var leftCurve: FBBezierCurve, rightCurve: FBBezierCurve
 
@@ -80,7 +80,7 @@ private func FBComputeEdge1RangeTangentCurves(edge: FBBezierCurve, intersectRang
 }
 
 // 66
-private func FBComputeEdge2RangeTangentCurves(edge: FBBezierCurve, intersectRange: FBBezierIntersectRange) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
+private func FBComputeEdge2RangeTangentCurves(_ edge: FBBezierCurve, intersectRange: FBBezierIntersectRange) -> (leftCurve: FBBezierCurve, rightCurve: FBBezierCurve) {
 
   var leftCurve: FBBezierCurve, rightCurve: FBBezierCurve
 
@@ -106,7 +106,7 @@ extension FBBezierCurve {
 
   // 119
   //- (void) addCrossing:(FBEdgeCrossing *)crossing
-  func addCrossing(crossing: FBEdgeCrossing) {
+  func addCrossing(_ crossing: FBEdgeCrossing) {
     // Make sure the crossing can make it back to us,
     // and keep all the crossings sorted
     crossing.edge = self
@@ -116,16 +116,16 @@ extension FBBezierCurve {
 
   // 127
   //- (void) removeCrossing:(FBEdgeCrossing *)crossing
-  func removeCrossing(crossing: FBEdgeCrossing) {
+  func removeCrossing(_ crossing: FBEdgeCrossing) {
     // Keep the crossings sorted
     //crossing.edge = nil   // cannot nil a non-optional
 
     //[_crossings removeObject:crossing];
-    for (index, element) in crossings.enumerate()
+    for (index, element) in crossings.enumerated()
     {
       if element === crossing
       {
-        crossings.removeAtIndex(index)
+        crossings.remove(at: index)
         break
       }
     }
@@ -205,9 +205,9 @@ extension FBBezierCurve {
 
   // 183
   //- (void) crossingsWithBlock:(void (^)(FBEdgeCrossing *crossing, BOOL *stop))block
-  func crossingsWithBlock(block: (crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool)) {
+  func crossingsWithBlock(_ block: (_ crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool)) {
     for crossing in crossings {
-      let (set, val) = block(crossing: crossing)
+      let (set, val) = block(crossing)
       if set && val {
         break
       }
@@ -217,10 +217,10 @@ extension FBBezierCurve {
   // 196
   //- (void) crossingsCopyWithBlock:(void (^)(FBEdgeCrossing *crossing, BOOL *stop))block
   // TODO: Check that this behaves the same as the original
-  func crossingsCopyWithBlock(block: (crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool)) {
+  func crossingsCopyWithBlock(_ block: (_ crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool)) {
     let crossingsCopy = crossings
     for crossing in crossingsCopy {
-      let (set, val) = block(crossing: crossing)
+      let (set, val) = block(crossing)
       if set && val {
         break
       }
@@ -229,7 +229,7 @@ extension FBBezierCurve {
 
   // 210
   //- (FBEdgeCrossing *) nextCrossing:(FBEdgeCrossing *)crossing
-  func nextCrossing(crossing: FBEdgeCrossing) -> FBEdgeCrossing? {
+  func nextCrossing(_ crossing: FBEdgeCrossing) -> FBEdgeCrossing? {
     if crossing.index < crossings.count - 1 {
       return crossings[crossing.index + 1]
     } else {
@@ -240,7 +240,7 @@ extension FBBezierCurve {
 
   // 218
   //- (FBEdgeCrossing *) previousCrossing:(FBEdgeCrossing *)crossing
-  func previousCrossing(crossing: FBEdgeCrossing) -> FBEdgeCrossing? {
+  func previousCrossing(_ crossing: FBEdgeCrossing) -> FBEdgeCrossing? {
     if crossing.index > 0 {
       return crossings[crossing.index - 1]
     } else {
@@ -250,7 +250,7 @@ extension FBBezierCurve {
 
   // 226
   //- (void) intersectingEdgesWithBlock:(void (^)(FBBezierCurve *intersectingEdge))block
-  func intersectingEdgesWithBlock(block: (intersectingEdge: FBBezierCurve) -> Void) {
+  func intersectingEdgesWithBlock(_ block: (_ intersectingEdge: FBBezierCurve) -> Void) {
 
     crossingsWithBlock() {
       (crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool) in
@@ -258,7 +258,7 @@ extension FBBezierCurve {
       // Right now skip over self intersecting crossings
       if !crossing.isSelfCrossing {
         if let crossingCounterpartEdge = crossing.counterpart?.edge {
-          block(intersectingEdge: crossingCounterpartEdge)
+          block(crossingCounterpartEdge)
         }
       }
       return (false, false)
@@ -268,14 +268,14 @@ extension FBBezierCurve {
 
   // 236
   //- (void) selfIntersectingEdgesWithBlock:(void (^)(FBBezierCurve *intersectingEdge))block
-  func selfIntersectingEdgesWithBlock(block: (intersectingEdge: FBBezierCurve) -> Void) {
+  func selfIntersectingEdgesWithBlock(_ block: (_ intersectingEdge: FBBezierCurve) -> Void) {
     crossingsWithBlock() {
       (crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool) in
 
       // Only want the self intersecting crossings
       if crossing.isSelfCrossing {
         if let crossingCounterpartEdge = crossing.counterpart?.edge {
-          block(intersectingEdge: crossingCounterpartEdge)
+          block(crossingCounterpartEdge)
         }
       }
       return (false, false)
@@ -329,7 +329,7 @@ extension FBBezierCurve {
 
   // 288
   //- (BOOL) crossesEdge:(FBBezierCurve *)edge2 atIntersection:(FBBezierIntersection *)intersection
-  func crossesEdge(edge2: FBBezierCurve, atIntersection intersection: FBBezierIntersection) -> Bool {
+  func crossesEdge(_ edge2: FBBezierCurve, atIntersection intersection: FBBezierIntersection) -> Bool {
     // If it's tangent, then it doesn't cross
     if intersection.isTangent {
       return false
@@ -379,7 +379,7 @@ extension FBBezierCurve {
 
   // 332
   //- (BOOL) crossesEdge:(FBBezierCurve *)edge2 atIntersectRange:(FBBezierIntersectRange *)intersectRange
-  func crossesEdge(edge2: FBBezierCurve, atIntersectRange intersectRange: FBBezierIntersectRange) -> Bool {
+  func crossesEdge(_ edge2: FBBezierCurve, atIntersectRange intersectRange: FBBezierIntersectRange) -> Bool {
     // Calculate the four tangents:
     // The two tangents moving away from the intersection point on self, and
     // the two tangents moving away from the intersection point on edge2.
@@ -414,13 +414,13 @@ extension FBBezierCurve {
 
   // 374
   //- (void) sortCrossings
-  private func sortCrossings() {
+  fileprivate func sortCrossings() {
 
     // Sort by the "order" of the crossing and then
     // assign indices so next and previous work correctly.
-    crossings.sortInPlace({ $0.order < $1.order })
+    crossings.sort(by: { $0.order < $1.order })
 
-    for (index, crossing) in crossings.enumerate() {
+    for (index, crossing) in crossings.enumerated() {
       crossing.index = index
     }
   }

--- a/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
@@ -28,8 +28,8 @@ import UIKit
 
 class FBBezierGraph {
 
-  private var _bounds : CGRect
-  private var _contours : [FBBezierContour]
+  fileprivate var _bounds : CGRect
+  fileprivate var _contours : [FBBezierContour]
 
   var contours : [FBBezierContour] {
     get {
@@ -39,25 +39,25 @@ class FBBezierGraph {
 
   init() {
     _contours = []
-    _bounds = CGRectNull
+    _bounds = CGRect.null
   }
 
   init(path: UIBezierPath) {
     _contours = []
-    _bounds = CGRectNull
+    _bounds = CGRect.null
     initWithBezierPath(path)
   }
 
-  class func bezierGraphWithBezierPath(path: UIBezierPath!) -> AnyObject {
+  class func bezierGraphWithBezierPath(_ path: UIBezierPath!) -> AnyObject {
     return FBBezierGraph().initWithBezierPath(path)
   }
 
   //- (id) initWithBezierPath:(NSBezierPath *)path
-  func initWithBezierPath(path: UIBezierPath!) -> FBBezierGraph {
+  func initWithBezierPath(_ path: UIBezierPath!) -> FBBezierGraph {
     // A bezier graph is made up of contours, which are closed paths of curves. Anytime we
     //  see a move to in the UIBezierPath, that's a new contour.
 
-    var lastPoint : CGPoint = CGPointZero
+    var lastPoint : CGPoint = CGPoint.zero
     var wasClosed = false
 
     var contour : FBBezierContour?
@@ -65,10 +65,10 @@ class FBBezierGraph {
 
     // This is done in a completely different way than was used for NSBezierPath
 
-    for (_, elem) in bezier.elements.enumerate() {
+    for (_, elem) in bezier.elements.enumerated() {
       switch elem {
 
-      case let .Move(toPt):
+      case let .move(toPt):
         // if previous contour wasn't closed, close it
         if !wasClosed && contour != nil {
           contour?.close()
@@ -78,9 +78,9 @@ class FBBezierGraph {
         addContour(contour!)
         lastPoint = toPt
 
-      case .Line(let toPt):
+      case .line(let toPt):
 
-        if !CGPointEqualToPoint(toPt, lastPoint) {
+        if !toPt.equalTo(lastPoint) {
           // Convert lines to bezier curves as well.
           // Just set control point to be in the line formed by the end points
           if let contour = contour {
@@ -90,11 +90,11 @@ class FBBezierGraph {
           lastPoint = toPt
         }
 
-      case .QuadCurve(let toPt, let via):
+      case .quadCurve(let toPt, let via):
 
         // GPC: skip degenerate case where all points are equal
-        let allPointsEqual = CGPointEqualToPoint(toPt, lastPoint)
-          && CGPointEqualToPoint(toPt, via)
+        let allPointsEqual = toPt.equalTo(lastPoint)
+          && toPt.equalTo(via)
 
         if !allPointsEqual {
           // Create a cubic curve representation of the quadratic curve from
@@ -113,19 +113,19 @@ class FBBezierGraph {
 
 
 
-      case .CubicCurve(let toPt, let v1, let v2):
+      case .cubicCurve(let toPt, let v1, let v2):
 
         // GPC: skip degenerate case where all points are equal
-        let allPointsEqual = CGPointEqualToPoint(toPt, lastPoint)
-          && CGPointEqualToPoint(toPt, v1)
-          && CGPointEqualToPoint(toPt, v2)
+        let allPointsEqual = toPt.equalTo(lastPoint)
+          && toPt.equalTo(v1)
+          && toPt.equalTo(v2)
 
         if !allPointsEqual {
           contour?.addCurve(FBBezierCurve(endPoint1: lastPoint, controlPoint1: v1, controlPoint2: v2, endPoint2: toPt))
           lastPoint = toPt
         }
 
-      case .Close:
+      case .close:
 
         // [MO] attempt to close the bezier contour by
         // mapping closepaths to equivalent lineto operations,
@@ -140,7 +140,7 @@ class FBBezierGraph {
             let firstPoint = firstEdge.endPoint1
 
             // Skip degenerate line segments
-            if !CGPointEqualToPoint(lastPoint, firstPoint) {
+            if !lastPoint.equalTo(firstPoint) {
               contour.addCurve(FBBezierCurve.bezierCurveWithLineStartPoint(lastPoint, endPoint:firstPoint))
               wasClosed = true
             }
@@ -179,7 +179,7 @@ class FBBezierGraph {
 
   // 218
   //- (FBBezierGraph *) unionWithBezierGraph:(FBBezierGraph *)graph
-  func unionWithBezierGraph(graph: FBBezierGraph) -> FBBezierGraph! {
+  func unionWithBezierGraph(_ graph: FBBezierGraph) -> FBBezierGraph! {
     // First insert FBEdgeCrossings into both graphs where the graphs
     //  cross.
     insertCrossingsWithBezierGraph(graph)
@@ -210,7 +210,7 @@ class FBBezierGraph {
 
   // 248
   //- (void) unionNonintersectingPartsIntoGraph:(FBBezierGraph *)result withGraph:(FBBezierGraph *)graph
-  private func unionNonintersectingPartsIntoGraph(inout result: FBBezierGraph, withGraph graph: FBBezierGraph) {
+  fileprivate func unionNonintersectingPartsIntoGraph(_ result: inout FBBezierGraph, withGraph graph: FBBezierGraph) {
 
     // Finally, process the contours that don't cross anything else. They're either
     //  completely contained in another contour, or disjoint.
@@ -229,11 +229,11 @@ class FBBezierGraph {
       let clipContainsSubject = graph.containsContour(ourContour)
       if clipContainsSubject {
         // [finalNonintersectingContours removeObject:ourContour];
-        for (index, element) in finalNonintersectingContours.enumerate()
+        for (index, element) in finalNonintersectingContours.enumerated()
         {
           if element === ourContour
           {
-            finalNonintersectingContours.removeAtIndex(index)
+            finalNonintersectingContours.remove(at: index)
             break
           }
         }
@@ -245,11 +245,11 @@ class FBBezierGraph {
       let subjectContainsClip = self.containsContour(theirContour)
       if subjectContainsClip {
         //[finalNonintersectingContours removeObject:theirContour];
-        for (index, element) in finalNonintersectingContours.enumerate()
+        for (index, element) in finalNonintersectingContours.enumerated()
         {
           if element === theirContour
           {
-            finalNonintersectingContours.removeAtIndex(index)
+            finalNonintersectingContours.remove(at: index)
             break
           }
         }
@@ -264,7 +264,7 @@ class FBBezierGraph {
 
   // 278
   //- (void) unionEquivalentNonintersectingContours:(NSMutableArray *)ourNonintersectingContours withContours:(NSMutableArray *)theirNonintersectingContours results:(NSMutableArray *)results
-  private func unionEquivalentNonintersectingContours(inout ourNonintersectingContours: [FBBezierContour], inout withContours theirNonintersectingContours: [FBBezierContour], inout results: [FBBezierContour]) {
+  fileprivate func unionEquivalentNonintersectingContours(_ ourNonintersectingContours: inout [FBBezierContour], withContours theirNonintersectingContours: inout [FBBezierContour], results: inout [FBBezierContour]) {
 
     var ourIndex = 0
     while ourIndex < ourNonintersectingContours.count {
@@ -279,38 +279,38 @@ class FBBezierGraph {
         if ourContour.inside == theirContour.inside  {
           // Redundant, so just remove one of them from the results
           // [results removeObject:theirContour];
-          for (index, element) in results.enumerate()
+          for (index, element) in results.enumerated()
           {
             if element === theirContour
             {
-              results.removeAtIndex(index)
+              results.remove(at: index)
               break
             }
           }
         } else {
           // One is a hole, one is a fill, so they cancel each other out. Remove both from the results
           //[results removeObject:theirContour];
-          for (index, element) in results.enumerate()
+          for (index, element) in results.enumerated()
           {
             if element === theirContour
             {
-              results.removeAtIndex(index)
+              results.remove(at: index)
               break
             }
           }
-          for (index, element) in results.enumerate()
+          for (index, element) in results.enumerated()
           {
             if element === ourContour
             {
-              results.removeAtIndex(index)
+              results.remove(at: index)
               break
             }
           }
         }
 
         // Remove both from the inputs so they aren't processed later
-        theirNonintersectingContours.removeAtIndex(theirIndex)
-        ourNonintersectingContours.removeAtIndex(ourIndex)
+        theirNonintersectingContours.remove(at: theirIndex)
+        ourNonintersectingContours.remove(at: ourIndex)
         ourIndex -= 1
         break
       }
@@ -320,7 +320,7 @@ class FBBezierGraph {
 
   // 306
   //- (FBBezierGraph *) intersectWithBezierGraph:(FBBezierGraph *)graph
-  func intersectWithBezierGraph(graph: FBBezierGraph) -> FBBezierGraph {
+  func intersectWithBezierGraph(_ graph: FBBezierGraph) -> FBBezierGraph {
 
     // First insert FBEdgeCrossings into both graphs where the graphs cross.
     insertCrossingsWithBezierGraph(graph)
@@ -351,7 +351,7 @@ class FBBezierGraph {
 
   // 335
   //- (void) intersectNonintersectingPartsIntoGraph:(FBBezierGraph *)result withGraph:(FBBezierGraph *)graph
-  private func intersectNonintersectingPartsIntoGraph(inout result: FBBezierGraph, withGraph graph: FBBezierGraph) {
+  fileprivate func intersectNonintersectingPartsIntoGraph(_ result: inout FBBezierGraph, withGraph graph: FBBezierGraph) {
     // Finally, process the contours that don't cross anything else. They're either
     //  completely contained in another contour, or disjoint.
     var ourNonintersectingContours = self.nonintersectingContours
@@ -385,7 +385,7 @@ class FBBezierGraph {
 
   // 365
   //- (void) intersectEquivalentNonintersectingContours:(NSMutableArray *)ourNonintersectingContours withContours:(NSMutableArray *)theirNonintersectingContours results:(NSMutableArray *)results
-  private func intersectEquivalentNonintersectingContours(inout ourNonintersectingContours: [FBBezierContour], inout withContours theirNonintersectingContours: [FBBezierContour]) -> [FBBezierContour] {
+  fileprivate func intersectEquivalentNonintersectingContours(_ ourNonintersectingContours: inout [FBBezierContour], withContours theirNonintersectingContours: inout [FBBezierContour]) -> [FBBezierContour] {
 
     var results: [FBBezierContour] = []
 
@@ -404,7 +404,7 @@ class FBBezierGraph {
           results.append(ourContour)
         } else {
           // One is a hole, one is a fill, so the hole cancels the fill. Add the hole to the results
-          if theirContour.inside == .Hole {
+          if theirContour.inside == .hole {
             // theirContour is the hole, so add it
             results.append(theirContour)
           } else {
@@ -414,8 +414,8 @@ class FBBezierGraph {
         }
 
         // Remove both from the inputs so they aren't processed later
-        theirNonintersectingContours.removeAtIndex(theirIndex)
-        ourNonintersectingContours.removeAtIndex(ourIndex)
+        theirNonintersectingContours.remove(at: theirIndex)
+        ourNonintersectingContours.remove(at: ourIndex)
         ourIndex -= 1
         break
       }
@@ -426,7 +426,7 @@ class FBBezierGraph {
 
   // 398
   //- (FBBezierGraph *) differenceWithBezierGraph:(FBBezierGraph *)graph
-  func differenceWithBezierGraph(graph: FBBezierGraph) -> FBBezierGraph {
+  func differenceWithBezierGraph(_ graph: FBBezierGraph) -> FBBezierGraph {
 
     // First insert FBEdgeCrossings into both graphs where the graphs cross.
     insertCrossingsWithBezierGraph(graph)
@@ -482,7 +482,7 @@ class FBBezierGraph {
 
   // 450
   //- (void) differenceEquivalentNonintersectingContours:(NSMutableArray *)ourNonintersectingContours withContours:(NSMutableArray *)theirNonintersectingContours results:(NSMutableArray *)results
-  private func differenceEquivalentNonintersectingContours(inout ourNonintersectingContours: [FBBezierContour], inout withContours theirNonintersectingContours: [FBBezierContour]) -> [FBBezierContour] {
+  fileprivate func differenceEquivalentNonintersectingContours(_ ourNonintersectingContours: inout [FBBezierContour], withContours theirNonintersectingContours: inout [FBBezierContour]) -> [FBBezierContour] {
 
     var results: [FBBezierContour] = []
 
@@ -500,7 +500,7 @@ class FBBezierGraph {
           // Trying to subtract a hole from a fill or vice versa does nothing,
           // so add the original to the results
           results.append(ourContour)
-        } else if ourContour.inside == .Hole && theirContour.inside == .Hole {
+        } else if ourContour.inside == .hole && theirContour.inside == .hole {
           // Subtracting a hole from a hole is redundant,
           // so just add one of them to the results
           results.append(ourContour)
@@ -511,8 +511,8 @@ class FBBezierGraph {
         }
 
         // Remove both from the inputs so they aren't processed later
-        theirNonintersectingContours.removeAtIndex(theirIndex)
-        ourNonintersectingContours.removeAtIndex(ourIndex)
+        theirNonintersectingContours.remove(at: theirIndex)
+        ourNonintersectingContours.remove(at: ourIndex)
         ourIndex -= 1
         break
       }
@@ -523,7 +523,7 @@ class FBBezierGraph {
 
   // 480
   //- (void) markCrossingsAsEntryOrExitWithBezierGraph:(FBBezierGraph *)otherGraph markInside:(BOOL)markInside
-  internal func markCrossingsAsEntryOrExitWithBezierGraph(otherGraph: FBBezierGraph, markInside: Bool) {
+  internal func markCrossingsAsEntryOrExitWithBezierGraph(_ otherGraph: FBBezierGraph, markInside: Bool) {
     // Walk each contour in ourself and mark the crossings with each intersecting contour as entering
     //  or exiting the final contour.
     for contour in contours {
@@ -536,7 +536,7 @@ class FBBezierGraph {
 
         //let adjustedMarkInside : Bool = (otherContour.inside == .Hole) != markInside
 
-        if otherContour.inside == .Hole {
+        if otherContour.inside == .hole {
           contour.markCrossingsAsEntryOrExitWithContour(otherContour, markInside: !markInside)
         } else {
           contour.markCrossingsAsEntryOrExitWithContour(otherContour, markInside: markInside)
@@ -548,7 +548,7 @@ class FBBezierGraph {
 
   // 499
   //- (FBBezierGraph *) xorWithBezierGraph:(FBBezierGraph *)graph
-  func xorWithBezierGraph(graph: FBBezierGraph) -> FBBezierGraph {
+  func xorWithBezierGraph(_ graph: FBBezierGraph) -> FBBezierGraph {
     // XOR is done by combing union (OR), intersect (AND) and difference.
     //
     // Specifically we compute the union of the two graphs and the intersect of them,
@@ -609,18 +609,18 @@ class FBBezierGraph {
       var firstPoint = true
       for edge in contour.edges {
         if firstPoint {
-          path.moveToPoint(edge.endPoint1)
+          path.move(to: edge.endPoint1)
           firstPoint = false
         }
 
         if edge.isStraightLine {
-          path.addLineToPoint(edge.endPoint2)
+          path.addLine(to: edge.endPoint2)
         } else {
-          path.addCurveToPoint(edge.endPoint2, controlPoint1: edge.controlPoint1, controlPoint2: edge.controlPoint2)
+          path.addCurve(to: edge.endPoint2, controlPoint1: edge.controlPoint1, controlPoint2: edge.controlPoint2)
         }
       }
-      if !path.empty {
-        path.closePath()  // GPC: close each contour
+      if !path.isEmpty {
+        path.close()  // GPC: close each contour
       }
     }
 
@@ -629,7 +629,7 @@ class FBBezierGraph {
 
   // 575
   //- (void) insertCrossingsWithBezierGraph:(FBBezierGraph *)other
-  internal func insertCrossingsWithBezierGraph(other: FBBezierGraph) {
+  internal func insertCrossingsWithBezierGraph(_ other: FBBezierGraph) {
 
     // Find all intersections and, if they cross the other graph,
     // create crossings for them, and insert them into each graph's edges.
@@ -712,7 +712,7 @@ class FBBezierGraph {
 
   // 639
   //- (void) cleanupCrossingsWithBezierGraph:(FBBezierGraph *)other
-  func cleanupCrossingsWithBezierGraph(other: FBBezierGraph) {
+  func cleanupCrossingsWithBezierGraph(_ other: FBBezierGraph) {
     // Remove duplicate crossings that can happen at end points of edges
     removeDuplicateCrossings()
     other.removeDuplicateCrossings()
@@ -750,7 +750,7 @@ class FBBezierGraph {
 
   // 667
   //- (void) removeDuplicateCrossings
-  private func removeDuplicateCrossings() {
+  fileprivate func removeDuplicateCrossings() {
     // Find any duplicate crossings. These will happen at the endpoints of edges.
     for ourContour in contours {
       for ourEdge in ourContour.edges {
@@ -758,7 +758,7 @@ class FBBezierGraph {
         ourEdge.crossingsCopyWithBlock() {
           (crossing: FBEdgeCrossing) -> (setStop: Bool, stopValue:Bool) in
 
-          if let crossingEdge = crossing.edge, lastCrossing = crossingEdge.previous.lastCrossing {
+          if let crossingEdge = crossing.edge, let lastCrossing = crossingEdge.previous.lastCrossing {
             if crossing.isAtStart && lastCrossing.isAtEnd {
               // Found a duplicate. Remove this crossing and its counterpart
               let counterpart = crossing.counterpart
@@ -769,7 +769,7 @@ class FBBezierGraph {
             }
           }
 
-          if let crossingEdge = crossing.edge, firstCrossing = crossingEdge.next.firstCrossing {
+          if let crossingEdge = crossing.edge, let firstCrossing = crossingEdge.next.firstCrossing {
             if crossing.isAtEnd && firstCrossing.isAtStart {
               // Found a duplicate. Remove this crossing and its counterpart
               let counterpart = firstCrossing.counterpart
@@ -875,16 +875,16 @@ class FBBezierGraph {
 
     // Compute the bounds of the graph by unioning together
     // the bounds of the individual contours
-    if !CGRectEqualToRect(_bounds, CGRectNull) {
+    if !_bounds.equalTo(CGRect.null) {
       return _bounds
     }
 
     if _contours.count == 0 {
-      return CGRectZero
+      return CGRect.zero
     }
 
     for contour in _contours {
-      _bounds = CGRectUnion(_bounds, contour.bounds)
+      _bounds = _bounds.union(contour.bounds)
     }
 
     return _bounds
@@ -893,7 +893,7 @@ class FBBezierGraph {
 
   // 765
   //- (FBContourInside) contourInsides:(FBBezierContour *)testContour
-  private func contourInsides(testContour: FBBezierContour) -> FBContourInside {
+  fileprivate func contourInsides(_ testContour: FBBezierContour) -> FBContourInside {
 
     // Determine if this contour, which should reside in this graph, is a filled region or
     //  a hole. Determine this by casting a ray from one edge of the contour to the outside of
@@ -912,7 +912,7 @@ class FBBezierGraph {
     let testPoint = testContour.testPointForContainment
 
     // Move us just outside the bounds of the graph
-    let beyondX = testPoint.x > CGRectGetMinX(self.bounds) ? CGRectGetMinX(self.bounds) - 10 : CGRectGetMaxX(self.bounds) + 10
+    let beyondX = testPoint.x > self.bounds.minX ? self.bounds.minX - 10 : self.bounds.maxX + 10
     let lineEndPoint = CGPoint(x: beyondX, y: testPoint.y)
     let testCurve = FBBezierCurve(startPoint: testPoint, endPoint: lineEndPoint)
 
@@ -933,15 +933,15 @@ class FBBezierGraph {
 
     // return (intersectCount & 1) == 1 ? .Hole : .Filled
     if intersectCount.isOdd {
-      return .Hole
+      return .hole
     } else {
-      return .Filled
+      return .filled
     }
   }
 
   // 791
   //- (FBCurveLocation *) closestLocationToPoint:(NSPoint)point
-  func closestLocationToPoint(point: CGPoint) -> FBCurveLocation? {
+  func closestLocationToPoint(_ point: CGPoint) -> FBCurveLocation? {
     var closestLocation : FBCurveLocation? = nil
 
     for contour in _contours {
@@ -962,13 +962,13 @@ class FBBezierGraph {
 
   // 809
   //- (NSBezierPath *) debugPathForContainmentOfContour:(FBBezierContour *)testContour
-  func debugPathForContainmentOfContour(testContour: FBBezierContour) -> UIBezierPath {
-    return debugPathForContainmentOfContour(testContour, transform: CGAffineTransformIdentity)
+  func debugPathForContainmentOfContour(_ testContour: FBBezierContour) -> UIBezierPath {
+    return debugPathForContainmentOfContour(testContour, transform: CGAffineTransform.identity)
   }
 
   // 814
   //- (NSBezierPath *) debugPathForContainmentOfContour:(FBBezierContour *)testContour transform:(NSAffineTransform *)transform
-  func debugPathForContainmentOfContour(testContour: FBBezierContour, transform: CGAffineTransform) -> UIBezierPath {
+  func debugPathForContainmentOfContour(_ testContour: FBBezierContour, transform: CGAffineTransform) -> UIBezierPath {
     let path = UIBezierPath()
 
     var intersectCount = 0
@@ -1019,7 +1019,7 @@ class FBBezierGraph {
       let testPoint = testContour.testPointForContainment
 
       // Move us just outside the bounds of the graph
-      let beyondX = testPoint.x > CGRectGetMinX(self.bounds) ? CGRectGetMinX(self.bounds) - 10 : CGRectGetMaxX(self.bounds) + 10
+      let beyondX = testPoint.x > self.bounds.minX ? self.bounds.minX - 10 : self.bounds.maxX + 10
       let lineEndPoint = CGPoint(x: beyondX, y: testPoint.y)
       let testCurve = FBBezierCurve(startPoint: testPoint, endPoint: lineEndPoint)
       contour.intersectionsWithRay(testCurve, withBlock: {
@@ -1034,13 +1034,13 @@ class FBBezierGraph {
     let testPoint = testContour.testPointForContainment
 
     // Move us just outside the bounds of the graph
-    let beyondX = testPoint.x > CGRectGetMinX(self.bounds) ? CGRectGetMinX(self.bounds) - 10 : CGRectGetMaxX(self.bounds) + 10
+    let beyondX = testPoint.x > self.bounds.minX ? self.bounds.minX - 10 : self.bounds.maxX + 10
     let lineEndPoint = CGPoint(x: beyondX, y: testPoint.y);
     let testCurve = FBBezierCurve(startPoint: testPoint, endPoint: lineEndPoint)
 
     let curvePath = testCurve.bezierPath
-    curvePath.applyTransform(transform)
-    path.appendPath(curvePath)
+    curvePath.apply(transform)
+    path.append(curvePath)
 
     // if this countour is flagged as "inside", the debug path is shown dashed, otherwise solid
 //    if (intersectCount & 1) == 1 {
@@ -1055,20 +1055,20 @@ class FBBezierGraph {
 
   // 882
   //- (NSBezierPath *) debugPathForJointsOfContour:(FBBezierContour *)testContour
-  func debugPathForJointsOfContour(testContour: FBBezierContour) -> UIBezierPath {
+  func debugPathForJointsOfContour(_ testContour: FBBezierContour) -> UIBezierPath {
     let path = UIBezierPath()
 
     for edge in testContour.edges {
       if !edge.isStraightLine {
-        path.moveToPoint(edge.endPoint1)
-        path.addLineToPoint(edge.controlPoint1)
-        path.appendPath(UIBezierPath.smallCircleAtPoint(edge.controlPoint1))
+        path.move(to: edge.endPoint1)
+        path.addLine(to: edge.controlPoint1)
+        path.append(UIBezierPath.smallCircleAtPoint(edge.controlPoint1))
 
-        path.moveToPoint(edge.endPoint2)
-        path.addLineToPoint(edge.controlPoint2)
-        path.appendPath(UIBezierPath.smallCircleAtPoint(edge.controlPoint2))
+        path.move(to: edge.endPoint2)
+        path.addLine(to: edge.controlPoint2)
+        path.append(UIBezierPath.smallCircleAtPoint(edge.controlPoint2))
       }
-      path.appendPath(UIBezierPath.smallRectAtPoint(edge.endPoint2))
+      path.append(UIBezierPath.smallRectAtPoint(edge.endPoint2))
     }
     
     return path
@@ -1077,7 +1077,7 @@ class FBBezierGraph {
 
   // 901
   //- (BOOL) containsContour:(FBBezierContour *)testContour
-  private func containsContour(testContour: FBBezierContour) -> Bool {
+  fileprivate func containsContour(_ testContour: FBBezierContour) -> Bool {
 
     // Determine the container, if any, for the test contour.
     // We do this by casting a ray from one end of the graph to the other,
@@ -1125,13 +1125,13 @@ class FBBezierGraph {
       // Send horizontal rays through the test contour
       //  and (possibly) through parts of the graph
       let verticalSpacing = (testContour.bounds.height) / CGFloat(fraction)
-      let yStart = CGRectGetMinY(testContour.bounds) + verticalSpacing
-      let yFinir = CGRectGetMaxY(testContour.bounds)
+      let yStart = testContour.bounds.minY + verticalSpacing
+      let yFinir = testContour.bounds.maxY
       var y = yStart
       while y < yFinir {
         // Construct a line that will reach outside both ends of both the test contour and graph
-        let rayStart = CGPoint(x: min(CGRectGetMinX(self.bounds), CGRectGetMinX(testContour.bounds)) - FBRayOverlap, y: y)
-        let rayFinir = CGPoint(x: max(CGRectGetMaxX(self.bounds), CGRectGetMaxX(testContour.bounds)) + FBRayOverlap, y: y)
+        let rayStart = CGPoint(x: min(self.bounds.minX, testContour.bounds.minX) - FBRayOverlap, y: y)
+        let rayFinir = CGPoint(x: max(self.bounds.maxX, testContour.bounds.maxX) + FBRayOverlap, y: y)
         let ray = FBBezierCurve(startPoint: rayStart, endPoint: rayFinir)
 
         // Eliminate any contours that aren't containers.
@@ -1146,13 +1146,13 @@ class FBBezierGraph {
       // Send vertical rays through the test contour
       //  and (possibly) through parts of the graph
       let horizontalSpacing = (testContour.bounds.width) / CGFloat(fraction)
-      let xStart = CGRectGetMinX(testContour.bounds) + horizontalSpacing
-      let xFinir = CGRectGetMaxX(testContour.bounds)
+      let xStart = testContour.bounds.minX + horizontalSpacing
+      let xFinir = testContour.bounds.maxX
       var x = xStart
       while x < xFinir {
         // Construct a line that will reach outside both ends of both the test contour and graph
-        let rayStart = CGPoint(x: x, y: min(CGRectGetMinY(self.bounds), CGRectGetMinY(testContour.bounds)) - FBRayOverlap)
-        let rayFinir = CGPoint(x: x, y: max(CGRectGetMaxY(self.bounds), CGRectGetMaxY(testContour.bounds)) + FBRayOverlap)
+        let rayStart = CGPoint(x: x, y: min(self.bounds.minY, testContour.bounds.minY) - FBRayOverlap)
+        let rayFinir = CGPoint(x: x, y: max(self.bounds.maxY, testContour.bounds.maxY) + FBRayOverlap)
         let ray = FBBezierCurve(startPoint: rayStart, endPoint: rayFinir)
 
         // Eliminate any contours that aren't containers.
@@ -1190,7 +1190,7 @@ class FBBezierGraph {
 
   // 967
   //- (BOOL) findBoundsOfContour:(FBBezierContour *)testContour onRay:(FBBezierCurve *)ray minimum:(NSPoint *)testMinimum maximum:(NSPoint *)testMaximum
-  private func findBoundsOfContour(testContour: FBBezierContour, onRay ray: FBBezierCurve, inout minimum testMinimum: CGPoint, inout maximum testMaximum: CGPoint) -> Bool {
+  fileprivate func findBoundsOfContour(_ testContour: FBBezierContour, onRay ray: FBBezierCurve, minimum testMinimum: inout CGPoint, maximum testMaximum: inout CGPoint) -> Bool {
 
     // Find the bounds of test contour that lie on ray.
     // Simply intersect the ray with test contour.
@@ -1244,7 +1244,7 @@ class FBBezierGraph {
 
   // 1004
   //- (BOOL) findCrossingsOnContainers:(NSArray *)containers onRay:(FBBezierCurve *)ray beforeMinimum:(NSPoint)testMinimum afterMaximum:(NSPoint)testMaximum crossingsBefore:(NSMutableArray *)crossingsBeforeMinimum crossingsAfter:(NSMutableArray *)crossingsAfterMaximum
-  private func findCrossingsOnContainers(containers: [FBBezierContour], onRay ray: FBBezierCurve, beforeMinimum testMinimum: CGPoint, afterMaximum testMaximum: CGPoint, inout crossingsBefore crossingsBeforeMinimum: [FBEdgeCrossing], inout crossingsAfter crossingsAfterMaximum: [FBEdgeCrossing]) -> Bool {
+  fileprivate func findCrossingsOnContainers(_ containers: [FBBezierContour], onRay ray: FBBezierCurve, beforeMinimum testMinimum: CGPoint, afterMaximum testMaximum: CGPoint, crossingsBefore crossingsBeforeMinimum: inout [FBEdgeCrossing], crossingsAfter crossingsAfterMaximum: inout [FBEdgeCrossing]) -> Bool {
 
     // Find intersections where the ray intersects the possible containers
     // before the minimum point, or after the maximum point.
@@ -1293,7 +1293,7 @@ class FBBezierGraph {
           // In that case it could fall on either side, and we'll need to do some special
           // processing on it later.
           // For now, remember it, and move on to the next intersection.
-          if CGPointEqualToPoint(testMaximum, testMinimum) && CGPointEqualToPoint(testMaximum, intersection.location) {
+          if testMaximum.equalTo(testMinimum) && testMaximum.equalTo(intersection.location) {
             ambiguousCrossings.append(crossing)
             return (false, false)
           }
@@ -1325,7 +1325,7 @@ class FBBezierGraph {
       // See how many times the given contour crosses on each side.
       // Add the ambigious crossing to the side that has less,
       // in hopes of balancing it out.
-      if let ambigEdge = ambiguousCrossing.edge, edgeContour = ambigEdge.contour {
+      if let ambigEdge = ambiguousCrossing.edge, let edgeContour = ambigEdge.contour {
         let numberOfTimesContourAppearsBefore = numberOfTimesContour(edgeContour, appearsInCrossings: crossingsBeforeMinimum)
         let numberOfTimesContourAppearsAfter = numberOfTimesContour(edgeContour, appearsInCrossings:crossingsAfterMaximum)
         if numberOfTimesContourAppearsBefore < numberOfTimesContourAppearsAfter {
@@ -1344,7 +1344,7 @@ class FBBezierGraph {
 
   // 1078
   //- (NSUInteger) numberOfTimesContour:(FBBezierContour *)contour appearsInCrossings:(NSArray *)crossings
-  private func numberOfTimesContour(contour: FBBezierContour, appearsInCrossings crossings: [FBEdgeCrossing]) -> Int {
+  fileprivate func numberOfTimesContour(_ contour: FBBezierContour, appearsInCrossings crossings: [FBEdgeCrossing]) -> Int {
     // Count how many times a contour appears in a crossings array
     var count = 0
     for crossing in crossings {
@@ -1360,7 +1360,7 @@ class FBBezierGraph {
 
   // 1089
   //- (BOOL) eliminateContainers:(NSMutableArray *)containers thatDontContainContour:(FBBezierContour *)testContour usingRay:(FBBezierCurve *)ray
-  private func eliminateContainers(inout containers: [FBBezierContour], thatDontContainContour testContour: FBBezierContour, usingRay ray: FBBezierCurve) -> Bool {
+  fileprivate func eliminateContainers(_ containers: inout [FBBezierContour], thatDontContainContour testContour: FBBezierContour, usingRay ray: FBBezierCurve) -> Bool {
 
     // This method attempts to eliminate all or all but one of the containers
     // that might contain the test contour, using the ray specified.
@@ -1402,7 +1402,7 @@ class FBBezierGraph {
 
   // 1123
   //- (NSArray *) contoursFromCrossings:(NSArray *)crossings
-  private func contoursFromCrossings(crossings: [FBEdgeCrossing]) -> [FBBezierContour] {
+  fileprivate func contoursFromCrossings(_ crossings: [FBEdgeCrossing]) -> [FBBezierContour] {
 
     // Determine all the unique contours in the array of crossings
     var contours : [FBBezierContour] = []
@@ -1422,7 +1422,7 @@ class FBBezierGraph {
 
   // 1134
   //- (void) removeContourCrossings:(NSMutableArray *)crossings1 thatDontAppearIn:(NSMutableArray *)crossings2
-  private func removeContourCrossings(inout crossings1: [FBEdgeCrossing], thatDontAppearIn crossings2: [FBEdgeCrossing]) {
+  fileprivate func removeContourCrossings(_ crossings1: inout [FBEdgeCrossing], thatDontAppearIn crossings2: [FBEdgeCrossing]) {
 
     // If a contour appears in crossings1, but not crossings2, remove all the associated crossings from
     //  crossings1.
@@ -1450,7 +1450,7 @@ class FBBezierGraph {
 
   // 1157
   //- (void) removeContoursThatDontContain:(NSMutableArray *)crossings
-  private func removeContoursThatDontContain(inout crossings: [FBEdgeCrossing]) {
+  fileprivate func removeContoursThatDontContain(_ crossings: inout [FBEdgeCrossing]) {
 
     // Remove contours that cross the ray an even number of times.
     // By the even/odd rule this means they can't contain the test contour.
@@ -1479,7 +1479,7 @@ class FBBezierGraph {
 
   // 1177
   //- (void) removeCrossings:(NSMutableArray *)crossings forContours:(NSArray *)containersToRemove
-  private func removeCrossings(inout crossings: [FBEdgeCrossing], forContours containersToRemove: [FBBezierContour]) {
+  fileprivate func removeCrossings(_ crossings: inout [FBEdgeCrossing], forContours containersToRemove: [FBBezierContour]) {
 
     // A helper method that goes through and removes all the
     // crossings that appear on the specified contours.
@@ -1497,11 +1497,11 @@ class FBBezierGraph {
     // Now walk through and remove the crossings
     for crossing in crossingsToRemove {
       //[crossings removeObject:crossing];
-      for (index, element) in crossings.enumerate()
+      for (index, element) in crossings.enumerated()
       {
         if element === crossing
         {
-          crossings.removeAtIndex(index)
+          crossings.remove(at: index)
           break
         }
       }
@@ -1511,7 +1511,7 @@ class FBBezierGraph {
 
   // 1195
   //- (void) markAllCrossingsAsUnprocessed
-  private func markAllCrossingsAsUnprocessed() {
+  fileprivate func markAllCrossingsAsUnprocessed() {
     for contour in _contours {
       for edge in contour.edges {
 
@@ -1528,7 +1528,7 @@ class FBBezierGraph {
 
   // 1205
   //- (FBEdgeCrossing *) firstUnprocessedCrossing
-  private var firstUnprocessedCrossing : FBEdgeCrossing? {
+  fileprivate var firstUnprocessedCrossing : FBEdgeCrossing? {
 
     // Find the first crossing in our graph that has yet to be processed
     // by the bezierGraphFromIntersections method.
@@ -1560,7 +1560,7 @@ class FBBezierGraph {
 
   // 1228
   //- (FBBezierGraph *) bezierGraphFromIntersections
-  private var bezierGraphFromIntersections : FBBezierGraph {
+  fileprivate var bezierGraphFromIntersections : FBBezierGraph {
 
     // This method walks the current graph, starting at the crossings,
     // and outputs the final contours of the parts of the graph that
@@ -1657,7 +1657,7 @@ class FBBezierGraph {
 
   // 1298
   //- (void) removeCrossings
-  private func removeCrossings() {
+  fileprivate func removeCrossings() {
     // Crossings only make sense for the intersection between two specific graphs.
     // In order for this graph to be usable in the future, remove all the crossings
     for contour in _contours {
@@ -1670,7 +1670,7 @@ class FBBezierGraph {
 
   // 1307
   //- (void) removeOverlaps
-  private func removeOverlaps() {
+  fileprivate func removeOverlaps() {
     for contour in _contours {
       contour.removeAllOverlaps()
     }
@@ -1678,15 +1678,15 @@ class FBBezierGraph {
 
   // 1313
   //- (void) addContour:(FBBezierContour *)contour
-  private func addContour(contour: FBBezierContour) {
+  fileprivate func addContour(_ contour: FBBezierContour) {
     // Add a contour to ouselves, and force the bounds to be recalculated
     _contours.append(contour)
-    _bounds = CGRectNull
+    _bounds = CGRect.null
   }
 
   // 1320
   //- (NSArray *) nonintersectingContours
-  private var nonintersectingContours : [FBBezierContour] {
+  fileprivate var nonintersectingContours : [FBBezierContour] {
     // Find all the contours that have no crossings on them.
     var contours : [FBBezierContour] = []
     for contour in self.contours {
@@ -1699,25 +1699,25 @@ class FBBezierGraph {
 
   // 1331
   //- (void) debuggingInsertCrossingsForUnionWithBezierGraph:(FBBezierGraph *)otherGraph
-  func debuggingInsertCrossingsForUnionWithBezierGraph(inout otherGraph: FBBezierGraph) {
+  func debuggingInsertCrossingsForUnionWithBezierGraph(_ otherGraph: inout FBBezierGraph) {
     debuggingInsertCrossingsWithBezierGraph(&otherGraph, markInside: false, markOtherInside: false)
   }
 
   // 1336
   //- (void) debuggingInsertCrossingsForIntersectWithBezierGraph:(FBBezierGraph *)otherGraph
-  func debuggingInsertCrossingsForIntersectWithBezierGraph(inout otherGraph: FBBezierGraph) {
+  func debuggingInsertCrossingsForIntersectWithBezierGraph(_ otherGraph: inout FBBezierGraph) {
     debuggingInsertCrossingsWithBezierGraph(&otherGraph, markInside: true, markOtherInside: true)
   }
 
   // 1341
   //- (void) debuggingInsertCrossingsForDifferenceWithBezierGraph:(FBBezierGraph *)otherGraph
-  func debuggingInsertCrossingsForDifferenceWithBezierGraph(inout otherGraph: FBBezierGraph) {
+  func debuggingInsertCrossingsForDifferenceWithBezierGraph(_ otherGraph: inout FBBezierGraph) {
     debuggingInsertCrossingsWithBezierGraph(&otherGraph, markInside: false, markOtherInside: true)
   }
 
   // 1346
   //- (void) debuggingInsertCrossingsWithBezierGraph:(FBBezierGraph *)otherGraph markInside:(BOOL)markInside markOtherInside:(BOOL)markOtherInside
-  private func debuggingInsertCrossingsWithBezierGraph(inout otherGraph: FBBezierGraph, markInside: Bool, markOtherInside: Bool) {
+  fileprivate func debuggingInsertCrossingsWithBezierGraph(_ otherGraph: inout FBBezierGraph, markInside: Bool, markOtherInside: Bool) {
 
     // Clean up crossings so the graphs can be reused, e.g. XOR will reuse graphs.
     self.removeCrossings()
@@ -1738,7 +1738,7 @@ class FBBezierGraph {
 
   // 1365
   //- (void) debuggingInsertIntersectionsWithBezierGraph:(FBBezierGraph *)otherGraph
-  private func debuggingInsertIntersectionsWithBezierGraph(inout otherGraph: FBBezierGraph) {
+  fileprivate func debuggingInsertIntersectionsWithBezierGraph(_ otherGraph: inout FBBezierGraph) {
 
     // Clean up crossings so the graphs can be reused, e.g. XOR will reuse graphs.
     self.removeCrossings()

--- a/Swift VectorBoolean/VectorBoolean/FBBezierIntersectRange.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierIntersectRange.swift
@@ -129,7 +129,7 @@ class FBBezierIntersectRange {
     )
   }
 
-  func merge(other: FBBezierIntersectRange) {
+  func merge(_ other: FBBezierIntersectRange) {
 
     // We assume the caller already knows we're talking about the same curves
     _parameterRange1 = FBRangeUnion(_parameterRange1, range2: other._parameterRange1);
@@ -138,7 +138,7 @@ class FBBezierIntersectRange {
     clearCache()
   }
 
-  private func clearCache() {
+  fileprivate func clearCache() {
     needToComputeCurve1 = true
     needToComputeCurve2 = true
 
@@ -151,7 +151,7 @@ class FBBezierIntersectRange {
   }
 
   //- (void) computeCurve1
-  private func computeCurve1()
+  fileprivate func computeCurve1()
   {
     if needToComputeCurve1 {
 
@@ -166,7 +166,7 @@ class FBBezierIntersectRange {
 
   // 114
   //- (void) computeCurve2
-  private func computeCurve2()
+  fileprivate func computeCurve2()
   {
     if needToComputeCurve2 {
 

--- a/Swift VectorBoolean/VectorBoolean/FBBezierIntersection.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierIntersection.swift
@@ -22,18 +22,18 @@ let FBParameterCloseThreshold = isRunningOn64BitDevice ? 1e-4 : 1e-2
 /// the left and right parts of the curves relative to
 /// the intersection point, and whether the intersection is tangent.
 class FBBezierIntersection {
-  private var _location : CGPoint?
-  private var _curve1: FBBezierCurve
-  private var _parameter1: Double
-  private var _curve1LeftBezier: FBBezierCurve?
-  private var _curve1RightBezier: FBBezierCurve?
-  private var _curve2: FBBezierCurve
-  private var _parameter2: Double
-  private var _curve2LeftBezier: FBBezierCurve?
-  private var _curve2RightBezier: FBBezierCurve?
-  private var _tangent: Bool = false
-  private var needToComputeCurve1 = true
-  private var needToComputeCurve2 = true
+  fileprivate var _location : CGPoint?
+  fileprivate var _curve1: FBBezierCurve
+  fileprivate var _parameter1: Double
+  fileprivate var _curve1LeftBezier: FBBezierCurve?
+  fileprivate var _curve1RightBezier: FBBezierCurve?
+  fileprivate var _curve2: FBBezierCurve
+  fileprivate var _parameter2: Double
+  fileprivate var _curve2LeftBezier: FBBezierCurve?
+  fileprivate var _curve2RightBezier: FBBezierCurve?
+  fileprivate var _tangent: Bool = false
+  fileprivate var needToComputeCurve1 = true
+  fileprivate var needToComputeCurve2 = true
 
   var location : CGPoint {
     computeCurve1()
@@ -154,7 +154,7 @@ class FBBezierIntersection {
 
 
   //- (void) computeCurve1
-  private func computeCurve1()
+  fileprivate func computeCurve1()
   {
     if needToComputeCurve1 {
       let pap = _curve1.pointAtParameter(_parameter1)
@@ -167,7 +167,7 @@ class FBBezierIntersection {
   }
 
   //- (void) computeCurve2
-  private func computeCurve2()
+  fileprivate func computeCurve2()
   {
     if needToComputeCurve2 {
       let pap = _curve2.pointAtParameter(_parameter2)

--- a/Swift VectorBoolean/VectorBoolean/FBContourOverlap.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBContourOverlap.swift
@@ -13,7 +13,7 @@ import UIKit
 
 class FBContourOverlap {
 
-  private var runs : [FBEdgeOverlapRun] = []
+  fileprivate var runs : [FBEdgeOverlapRun] = []
 
   /* ======== THESE ARE PUBLIC ===========
   - (void) addOverlap:(FBBezierIntersectRange *)range forEdge1:(FBBezierCurve *)edge1 edge2:(FBBezierCurve *)edge2;
@@ -35,7 +35,7 @@ class FBContourOverlap {
 
 
   //- (void) addOverlap:(FBBezierIntersectRange *)range forEdge1:(FBBezierCurve *)edge1 edge2:(FBBezierCurve *)edge2
-  func addOverlap(range: FBBezierIntersectRange, forEdge1 edge1: FBBezierCurve, edge2: FBBezierCurve) {
+  func addOverlap(_ range: FBBezierIntersectRange, forEdge1 edge1: FBBezierCurve, edge2: FBBezierCurve) {
     let overlap = FBEdgeOverlap(range: range, edge1: edge1, edge2: edge2)
 
     var createNewRun = false
@@ -61,7 +61,7 @@ class FBContourOverlap {
   }
 
   //- (BOOL) doesContainCrossing:(FBEdgeCrossing *)crossing
-  func doesContainCrossing(crossing: FBEdgeCrossing) -> Bool {
+  func doesContainCrossing(_ crossing: FBEdgeCrossing) -> Bool {
     if runs.count == 0 {
       return false
     }
@@ -76,7 +76,7 @@ class FBContourOverlap {
   }
 
   //- (BOOL) doesContainParameter:(CGFloat)parameter onEdge:(FBBezierCurve *)edge
-  func doesContainParameter(parameter: Double, onEdge edge: FBBezierCurve) -> Bool {
+  func doesContainParameter(_ parameter: Double, onEdge edge: FBBezierCurve) -> Bool {
     if runs.count == 0 {
       return false
     }
@@ -91,14 +91,14 @@ class FBContourOverlap {
   }
 
   //- (void) runsWithBlock:(void (^)(FBEdgeOverlapRun *run, BOOL *stop))block
-  func runsWithBlock(block: (run: FBEdgeOverlapRun) -> Bool)
+  func runsWithBlock(_ block: (_ run: FBEdgeOverlapRun) -> Bool)
   {
     if runs.count == 0 {
       return
     }
 
     for run in runs {
-      let stop = block(run: run)
+      let stop = block(run)
       if stop {
         break
       }
@@ -158,7 +158,7 @@ class FBContourOverlap {
 
 
   //- (BOOL) isBetweenContour:(FBBezierContour *)contour1 andContour:(FBBezierContour *)contour2
-  func isBetweenContour(contour1: FBBezierContour, andContour contour2: FBBezierContour) -> Bool {
+  func isBetweenContour(_ contour1: FBBezierContour, andContour contour2: FBBezierContour) -> Bool {
     let myContour1 = self.contour1
     let myContour2 = self.contour2
 

--- a/Swift VectorBoolean/VectorBoolean/FBCurveLocation.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBCurveLocation.swift
@@ -15,9 +15,9 @@ class FBCurveLocation {
 
   var graph : FBBezierGraph?
   var contour : FBBezierContour?
-  private var _edge : FBBezierCurve
-  private var _parameter : Double
-  private var _distance : Double
+  fileprivate var _edge : FBBezierCurve
+  fileprivate var _parameter : Double
+  fileprivate var _distance : Double
 
   init(edge: FBBezierCurve, parameter: Double, distance: Double) {
     _edge = edge

--- a/Swift VectorBoolean/VectorBoolean/FBEdgeCrossing.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBEdgeCrossing.swift
@@ -18,7 +18,7 @@ import UIKit
 /// crossing's counterpart in the other FBBezierGraph
 class FBEdgeCrossing {
 
-  private var _intersection: FBBezierIntersection
+  fileprivate var _intersection: FBBezierIntersection
 
   var edge: FBBezierCurve?
   var counterpart: FBEdgeCrossing?

--- a/Swift VectorBoolean/VectorBoolean/FBEdgeOverlap.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBEdgeOverlap.swift
@@ -16,7 +16,7 @@ let FBOverlapThreshold = isRunningOn64BitDevice ? 1e-2 : 1e-1
 class FBEdgeOverlap {
   var edge1 : FBBezierCurve
   var edge2 : FBBezierCurve
-  private var _range : FBBezierIntersectRange
+  fileprivate var _range : FBBezierIntersectRange
 
   var range : FBBezierIntersectRange {
     return _range
@@ -29,7 +29,7 @@ class FBEdgeOverlap {
   }
 
   //- (BOOL) fitsBefore:(FBEdgeOverlap *)nextOverlap
-  func fitsBefore(nextOverlap: FBEdgeOverlap) -> Bool {
+  func fitsBefore(_ nextOverlap: FBEdgeOverlap) -> Bool {
     if FBAreValuesCloseWithOptions(range.parameterRange1.maximum, value2: 1.0, threshold: FBOverlapThreshold) {
       // nextOverlap should start at 0 of the next edge
       let nextEdge = edge1.next
@@ -41,7 +41,7 @@ class FBEdgeOverlap {
   }
 
   //- (BOOL) fitsAfter:(FBEdgeOverlap *)previousOverlap
-  func fitsAfter(previousOverlap: FBEdgeOverlap) -> Bool {
+  func fitsAfter(_ previousOverlap: FBEdgeOverlap) -> Bool {
     if FBAreValuesCloseWithOptions(range.parameterRange1.minimum, value2: 0.0, threshold: FBOverlapThreshold) {
       // previousOverlap should end at 1 of the previous edge
       let previousEdge = edge1.previous
@@ -72,7 +72,7 @@ class FBEdgeOverlap {
   }
 
   //- (BOOL) doesContainParameter:(CGFloat)parameter onEdge:(FBBezierCurve *)edge startExtends:(BOOL)extendsBeforeStart endExtends:(BOOL)extendsAfterEnd
-  func doesContainParameter(parameter: Double, onEdge edge:FBBezierCurve, startExtends extendsBeforeStart: Bool, endExtends extendsAfterEnd: Bool) -> Bool {
+  func doesContainParameter(_ parameter: Double, onEdge edge:FBBezierCurve, startExtends extendsBeforeStart: Bool, endExtends extendsAfterEnd: Bool) -> Bool {
 
     // By the time this is called, we know the crossing is on one of our edges.
     if extendsBeforeStart && extendsAfterEnd {

--- a/Swift VectorBoolean/VectorBoolean/FBEdgeOverlapRun.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBEdgeOverlapRun.swift
@@ -17,7 +17,8 @@ class FBEdgeOverlapRun {
 
 
   //- (BOOL) insertOverlap:(FBEdgeOverlap *)overlap
-  func insertOverlap(overlap: FBEdgeOverlap) -> Bool {
+  @discardableResult
+  func insertOverlap(_ overlap: FBEdgeOverlap) -> Bool {
 
     if overlaps.count == 0 {
       // The first one always works
@@ -36,7 +37,7 @@ class FBEdgeOverlapRun {
     // Check to see if overlap fits before our first overlap
     if let firstOverlap = overlaps.first {
       if firstOverlap.fitsAfter(overlap) {
-        overlaps.insert(overlap, atIndex: 0)
+        overlaps.insert(overlap, at: 0)
         return true
       }
     }
@@ -62,7 +63,7 @@ class FBEdgeOverlapRun {
 
 
   //- (BOOL) doesContainCrossing:(FBEdgeCrossing *)crossing
-  func doesContainCrossing(crossing: FBEdgeCrossing) -> Bool {
+  func doesContainCrossing(_ crossing: FBEdgeCrossing) -> Bool {
     if let crossingEdge = crossing.edge {
       return doesContainParameter(crossing.parameter, onEdge: crossingEdge)
     } else {
@@ -72,7 +73,7 @@ class FBEdgeOverlapRun {
 
 
   //- (BOOL) doesContainParameter:(CGFloat)parameter onEdge:(FBBezierCurve *)edge
-  func doesContainParameter(parameter: Double, onEdge edge: FBBezierCurve) -> Bool {
+  func doesContainParameter(_ parameter: Double, onEdge edge: FBBezierCurve) -> Bool {
     if overlaps.count == 0 {
       return false
     }
@@ -207,7 +208,7 @@ class FBEdgeOverlapRun {
 // =============================
 
 //static CGFloat FBComputeEdge1Tangents(FBEdgeOverlap *firstOverlap, FBEdgeOverlap *lastOverlap, CGFloat offset, NSPoint edge1Tangents[2])
-func FBComputeEdge1Tangents(firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOverlap, offset: Double, inout edge1Tangents: FBTangentPair) -> Double {
+func FBComputeEdge1Tangents(_ firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOverlap, offset: Double, edge1Tangents: inout FBTangentPair) -> Double {
 
   // edge1Tangents are firstOverlap.range1.minimum going to previous
   // and lastOverlap.range1.maximum going to next
@@ -238,7 +239,7 @@ func FBComputeEdge1Tangents(firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOver
 
 
 //static CGFloat FBComputeEdge2Tangents(FBEdgeOverlap *firstOverlap, FBEdgeOverlap *lastOverlap, CGFloat offset, NSPoint edge2Tangents[2])
-func FBComputeEdge2Tangents(firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOverlap, offset: Double, inout edge2Tangents: FBTangentPair) -> Double {
+func FBComputeEdge2Tangents(_ firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOverlap, offset: Double, edge2Tangents: inout FBTangentPair) -> Double {
 
   // edge2Tangents are firstOverlap.range2.minimum going to previous
   // and lastOverlap.range2.maximum going to next
@@ -292,7 +293,7 @@ func FBComputeEdge2Tangents(firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOver
 }
 
 //static void FBComputeEdge1TestPoints(FBEdgeOverlap *firstOverlap, FBEdgeOverlap *lastOverlap, CGFloat offset, NSPoint testPoints[2])
-func FBComputeEdge1TestPoints(firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOverlap, offset: Double, inout testPoints: FBTangentPair) {
+func FBComputeEdge1TestPoints(_ firstOverlap: FBEdgeOverlap, lastOverlap: FBEdgeOverlap, offset: Double, testPoints: inout FBTangentPair) {
 
   // edge1Tangents are firstOverlap.range1.minimum going to previous
   // and lastOverlap.range1.maximum going to next

--- a/Swift VectorBoolean/VectorBoolean/FBGeometry.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBGeometry.swift
@@ -16,7 +16,7 @@ import UIKit
 // MARK: Point Helpers
 // ===================================
 
-let isRunningOn64BitDevice = sizeof(Int) == sizeof(Int64)
+let isRunningOn64BitDevice = MemoryLayout<Int>.size == MemoryLayout<Int64>.size
 
 var FBPointClosenessThreshold: Double {
   if isRunningOn64BitDevice {
@@ -40,7 +40,7 @@ var FBBoundsClosenessThreshold: Double {
   }
 }
 
-func FBDistanceBetweenPoints(point1: CGPoint, point2: CGPoint) -> Double {
+func FBDistanceBetweenPoints(_ point1: CGPoint, point2: CGPoint) -> Double {
 
   let xDelta = Double(point2.x - point1.x)
   let yDelta = Double(point2.y - point1.y)
@@ -48,7 +48,7 @@ func FBDistanceBetweenPoints(point1: CGPoint, point2: CGPoint) -> Double {
   return sqrt(xDelta * xDelta + yDelta * yDelta);
 }
 
-func FBDistancePointToLine(point: CGPoint, lineStartPoint: CGPoint, lineEndPoint: CGPoint) -> Double {
+func FBDistancePointToLine(_ point: CGPoint, lineStartPoint: CGPoint, lineEndPoint: CGPoint) -> Double {
 
   let lineLength = FBDistanceBetweenPoints(lineStartPoint, point2: lineEndPoint)
   if lineLength == 0.0 {
@@ -70,14 +70,14 @@ func FBDistancePointToLine(point: CGPoint, lineStartPoint: CGPoint, lineEndPoint
   return FBDistanceBetweenPoints(point, point2: intersectionPoint)
 }
 
-func FBAddPoint(point1: CGPoint, point2: CGPoint) -> CGPoint {
+func FBAddPoint(_ point1: CGPoint, point2: CGPoint) -> CGPoint {
 
   return CGPoint(
     x: point1.x + point2.x,
     y: point1.y + point2.y)
 }
 
-func FBUnitScalePoint(point: CGPoint, scale: Double) -> CGPoint {
+func FBUnitScalePoint(_ point: CGPoint, scale: Double) -> CGPoint {
 
   var result = point
   let length = FBPointLength(point)
@@ -88,40 +88,40 @@ func FBUnitScalePoint(point: CGPoint, scale: Double) -> CGPoint {
   return result
 }
 
-func FBScalePoint(point: CGPoint, scale: CGFloat) -> CGPoint {
+func FBScalePoint(_ point: CGPoint, scale: CGFloat) -> CGPoint {
 
   return CGPoint(
     x: point.x * scale,
     y: point.y * scale)
 }
 
-func FBDotMultiplyPoint(point1: CGPoint, point2: CGPoint) -> Double {
+func FBDotMultiplyPoint(_ point1: CGPoint, point2: CGPoint) -> Double {
 
   let dotX = Double(point1.x) * Double(point2.x)
   let dotY = Double(point1.y) * Double(point2.y)
   return dotX + dotY
 }
 
-func FBSubtractPoint(point1: CGPoint, point2: CGPoint) -> CGPoint {
+func FBSubtractPoint(_ point1: CGPoint, point2: CGPoint) -> CGPoint {
 
   return CGPoint(
     x: point1.x - point2.x,
     y: point1.y - point2.y)
 }
 
-func FBPointLength(point: CGPoint) -> Double {
+func FBPointLength(_ point: CGPoint) -> Double {
   let xSq = Double(point.x) * Double(point.x)
   let ySq = Double(point.y) * Double(point.y)
   return sqrt(xSq + ySq)
 }
 
-func FBPointSquaredLength(point: CGPoint) -> Double {
+func FBPointSquaredLength(_ point: CGPoint) -> Double {
   let xSq = Double(point.x) * Double(point.x)
   let ySq = Double(point.y) * Double(point.y)
   return xSq + ySq
 }
 
-func FBNormalizePoint(point: CGPoint) -> CGPoint {
+func FBNormalizePoint(_ point: CGPoint) -> CGPoint {
 
   var result = point
   let length = FBPointLength(point)
@@ -132,63 +132,63 @@ func FBNormalizePoint(point: CGPoint) -> CGPoint {
   return result
 }
 
-func FBNegatePoint(point: CGPoint) -> CGPoint {
+func FBNegatePoint(_ point: CGPoint) -> CGPoint {
 
   return CGPoint(
     x: -point.x,
     y: -point.y)
 }
 
-func FBRoundPoint(point: CGPoint) -> CGPoint {
+func FBRoundPoint(_ point: CGPoint) -> CGPoint {
 
   return CGPoint(
     x: round(point.x),
     y: round(point.y))
 }
 
-func FBLineNormal(lineStart: CGPoint, lineEnd: CGPoint) -> CGPoint {
+func FBLineNormal(_ lineStart: CGPoint, lineEnd: CGPoint) -> CGPoint {
 
   return FBNormalizePoint(CGPoint(
     x: -(lineEnd.y - lineStart.y),
     y: lineEnd.x - lineStart.x))
 }
 
-func FBLineMidpoint(lineStart: CGPoint, lineEnd: CGPoint) -> CGPoint {
+func FBLineMidpoint(_ lineStart: CGPoint, lineEnd: CGPoint) -> CGPoint {
 
   let distance = FBDistanceBetweenPoints(lineStart, point2: lineEnd)
   let tangent = FBNormalizePoint(FBSubtractPoint(lineEnd, point2: lineStart))
   return FBAddPoint(lineStart, point2: FBUnitScalePoint(tangent, scale: distance / 2.0))
 }
 
-func FBRectGetTopLeft(rect : CGRect) -> CGPoint {
+func FBRectGetTopLeft(_ rect : CGRect) -> CGPoint {
 
   return CGPoint(
-    x: CGRectGetMinX(rect),
-    y: CGRectGetMinY(rect))
+    x: rect.minX,
+    y: rect.minY)
 }
 
-func FBRectGetTopRight(rect : CGRect) -> CGPoint {
+func FBRectGetTopRight(_ rect : CGRect) -> CGPoint {
 
   return CGPoint(
-    x: CGRectGetMaxX(rect),
-    y: CGRectGetMinY(rect))
+    x: rect.maxX,
+    y: rect.minY)
 }
 
-func FBRectGetBottomLeft(rect : CGRect) -> CGPoint {
+func FBRectGetBottomLeft(_ rect : CGRect) -> CGPoint {
 
   return CGPoint(
-    x: CGRectGetMinX(rect),
-    y: CGRectGetMaxY(rect))
+    x: rect.minX,
+    y: rect.maxY)
 }
 
-func FBRectGetBottomRight(rect : CGRect) -> CGPoint {
+func FBRectGetBottomRight(_ rect : CGRect) -> CGPoint {
 
   return CGPoint(
-    x: CGRectGetMaxX(rect),
-    y: CGRectGetMaxY(rect))
+    x: rect.maxX,
+    y: rect.maxY)
 }
 
-func FBExpandBoundsByPoint(inout topLeft: CGPoint, inout bottomRight: CGPoint, point: CGPoint) {
+func FBExpandBoundsByPoint(_ topLeft: inout CGPoint, bottomRight: inout CGPoint, point: CGPoint) {
 
   if point.x < topLeft.x     { topLeft.x = point.x }
 
@@ -199,7 +199,7 @@ func FBExpandBoundsByPoint(inout topLeft: CGPoint, inout bottomRight: CGPoint, p
   if point.y > bottomRight.y { bottomRight.y = point.y }
 }
 
-func FBUnionRect(rect1: CGRect, rect2: CGRect) -> CGRect {
+func FBUnionRect(_ rect1: CGRect, rect2: CGRect) -> CGRect {
 
   var topLeft = FBRectGetTopLeft(rect1)
   var bottomRight = FBRectGetBottomRight(rect1)
@@ -221,27 +221,27 @@ func FBUnionRect(rect1: CGRect, rect2: CGRect) -> CGRect {
 // ===================================
 
 
-func FBArePointsClose(point1: CGPoint, point2: CGPoint) -> Bool {
+func FBArePointsClose(_ point1: CGPoint, point2: CGPoint) -> Bool {
 
   return FBArePointsCloseWithOptions(point1, point2: point2, threshold: FBPointClosenessThreshold)
 }
 
-func FBArePointsCloseWithOptions(point1: CGPoint, point2: CGPoint, threshold: Double) -> Bool {
+func FBArePointsCloseWithOptions(_ point1: CGPoint, point2: CGPoint, threshold: Double) -> Bool {
 
   return FBAreValuesCloseWithOptions(Double(point1.x), value2: Double(point2.x), threshold: threshold) && FBAreValuesCloseWithOptions(Double(point1.y), value2: Double(point2.y), threshold: threshold);
 }
 
-func FBAreValuesClose(value1: CGFloat, value2: CGFloat) -> Bool {
+func FBAreValuesClose(_ value1: CGFloat, value2: CGFloat) -> Bool {
 
   return FBAreValuesCloseWithOptions(Double(value1), value2: Double(value2), threshold: FBPointClosenessThreshold)
 }
 
-func FBAreValuesClose(value1: Double, value2: Double) -> Bool {
+func FBAreValuesClose(_ value1: Double, value2: Double) -> Bool {
 
   return FBAreValuesCloseWithOptions(value1, value2: value2, threshold: Double(FBPointClosenessThreshold))
 }
 
-func FBAreValuesCloseWithOptions(value1: Double, value2: Double, threshold: Double) -> Bool {
+func FBAreValuesCloseWithOptions(_ value1: Double, value2: Double, threshold: Double) -> Bool {
 
   let delta = value1 - value2
   return (delta <= threshold) && (delta >= -threshold)
@@ -265,7 +265,7 @@ let Half_π = M_PI_2
 
 
 // Normalize the angle between 0 and 2 π
-func NormalizeAngle(value: Double) -> Double {
+func NormalizeAngle(_ value: Double) -> Double {
   var value = value
   while value < 0.0 {  value = value + Two_π }
   while value >= Two_π { value = value - Two_π }
@@ -274,7 +274,7 @@ func NormalizeAngle(value: Double) -> Double {
 }
 
 // Compute the polar angle from the cartesian point
-func PolarAngle(point: CGPoint) -> Double {
+func PolarAngle(_ point: CGPoint) -> Double {
 
   var value = 0.0
   let dpx = Double(point.x)
@@ -338,12 +338,12 @@ struct FBAngleRange {
 //  return value > minimum
 //}
 //
-func FBIsValueGreaterThan(value: CGFloat, minimum: CGFloat) -> Bool {
+func FBIsValueGreaterThan(_ value: CGFloat, minimum: CGFloat) -> Bool {
 
   return FBIsValueGreaterThanWithOptions(Double(value), minimum: Double(minimum), threshold: FBTangentClosenessThreshold)
 }
 
-func FBIsValueGreaterThanWithOptions(value: Double, minimum: Double, threshold: Double) -> Bool {
+func FBIsValueGreaterThanWithOptions(_ value: Double, minimum: Double, threshold: Double) -> Bool {
 
   if FBAreValuesCloseWithOptions(value, value2: minimum, threshold: threshold) {
     return false
@@ -352,12 +352,12 @@ func FBIsValueGreaterThanWithOptions(value: Double, minimum: Double, threshold: 
   return value > minimum
 }
 
-func FBIsValueGreaterThan(value: Double, minimum: Double) -> Bool {
+func FBIsValueGreaterThan(_ value: Double, minimum: Double) -> Bool {
 
   return FBIsValueGreaterThanWithOptions(value, minimum: minimum, threshold: Double(FBTangentClosenessThreshold))
 }
 
-func FBIsValueLessThan(value: CGFloat, maximum: CGFloat) -> Bool {
+func FBIsValueLessThan(_ value: CGFloat, maximum: CGFloat) -> Bool {
 
   if FBAreValuesCloseWithOptions(Double(value), value2: Double(maximum), threshold: FBTangentClosenessThreshold) {
     return false
@@ -366,7 +366,7 @@ func FBIsValueLessThan(value: CGFloat, maximum: CGFloat) -> Bool {
   return value < maximum
 }
 
-func FBIsValueLessThan(value: Double, maximum: Double) -> Bool {
+func FBIsValueLessThan(_ value: Double, maximum: Double) -> Bool {
 
   if FBAreValuesCloseWithOptions(value, value2: maximum, threshold: Double(FBTangentClosenessThreshold)) {
     return false
@@ -375,7 +375,7 @@ func FBIsValueLessThan(value: Double, maximum: Double) -> Bool {
   return value < maximum
 }
 
-func FBIsValueGreaterThanEqual(value: CGFloat, minimum: CGFloat) -> Bool {
+func FBIsValueGreaterThanEqual(_ value: CGFloat, minimum: CGFloat) -> Bool {
 
   if FBAreValuesCloseWithOptions(Double(value), value2: Double(minimum), threshold: FBTangentClosenessThreshold) {
     return true
@@ -384,7 +384,7 @@ func FBIsValueGreaterThanEqual(value: CGFloat, minimum: CGFloat) -> Bool {
   return value >= minimum
 }
 
-func FBIsValueGreaterThanEqual(value: Double, minimum: Double) -> Bool {
+func FBIsValueGreaterThanEqual(_ value: Double, minimum: Double) -> Bool {
 
   if FBAreValuesCloseWithOptions(value, value2: minimum, threshold: Double(FBTangentClosenessThreshold)) {
     return true
@@ -402,7 +402,7 @@ func FBIsValueGreaterThanEqual(value: Double, minimum: Double) -> Bool {
 //  return value <= maximum
 //}
 
-func FBIsValueLessThanEqualWithOptions(value: Double, maximum: Double, threshold: Double) -> Bool {
+func FBIsValueLessThanEqualWithOptions(_ value: Double, maximum: Double, threshold: Double) -> Bool {
 
   if FBAreValuesCloseWithOptions(value, value2: maximum, threshold: threshold) {
     return true
@@ -411,18 +411,18 @@ func FBIsValueLessThanEqualWithOptions(value: Double, maximum: Double, threshold
   return value <= maximum
 }
 
-func FBIsValueLessThanEqual(value: CGFloat, maximum: CGFloat) -> Bool {
+func FBIsValueLessThanEqual(_ value: CGFloat, maximum: CGFloat) -> Bool {
 
   return FBIsValueLessThanEqualWithOptions(Double(value), maximum: Double(maximum), threshold: FBTangentClosenessThreshold)
 }
 
-func FBIsValueLessThanEqual(value: Double, maximum: Double) -> Bool {
+func FBIsValueLessThanEqual(_ value: Double, maximum: Double) -> Bool {
 
   return FBIsValueLessThanEqualWithOptions(value, maximum: maximum, threshold: FBTangentClosenessThreshold)
 }
 
 
-func FBAngleRangeContainsAngle(range: FBAngleRange, angle: Double) -> Bool {
+func FBAngleRangeContainsAngle(_ range: FBAngleRange, angle: Double) -> Bool {
 
   if range.minimum <= range.maximum {
     return FBIsValueGreaterThan(angle, minimum: range.minimum) && FBIsValueLessThan(angle, maximum: range.maximum)
@@ -448,29 +448,29 @@ struct FBRange {
   var maximum : Double
 }
 
-func FBRangeHasConverged(range: FBRange, decimalPlaces: Int) -> Bool {
+func FBRangeHasConverged(_ range: FBRange, decimalPlaces: Int) -> Bool {
   let factor = pow(10.0, Double(decimalPlaces))
   let minimum = Int(range.minimum * factor)
   let maxiumum = Int(range.maximum * factor)
   return minimum == maxiumum
 }
 
-func FBRangeGetSize(range: FBRange) -> Double {
+func FBRangeGetSize(_ range: FBRange) -> Double {
 
   return range.maximum - range.minimum
 }
 
-func FBRangeAverage(range: FBRange) -> Double {
+func FBRangeAverage(_ range: FBRange) -> Double {
 
   return (range.minimum + range.maximum) / 2.0
 }
 
-func FBRangeScaleNormalizedValue(range: FBRange, value: Double) -> Double {
+func FBRangeScaleNormalizedValue(_ range: FBRange, value: Double) -> Double {
 
   return (range.maximum - range.minimum) * value + range.minimum
 }
 
-func FBRangeUnion(range1: FBRange, range2: FBRange) -> FBRange {
+func FBRangeUnion(_ range1: FBRange, range2: FBRange) -> FBRange {
 
   return FBRange(minimum: min(range1.minimum, range2.minimum), maximum: max(range1.maximum, range2.maximum))
 }
@@ -486,7 +486,7 @@ struct FBTangentPair {
   var right: CGPoint
 }
 
-func FBAreTangentsAmbigious(edge1Tangents: FBTangentPair, edge2Tangents: FBTangentPair) -> Bool {
+func FBAreTangentsAmbigious(_ edge1Tangents: FBTangentPair, edge2Tangents: FBTangentPair) -> Bool {
 
   let normalEdge1 = FBTangentPair(left: FBNormalizePoint(edge1Tangents.left), right: FBNormalizePoint(edge1Tangents.right))
   let normalEdge2 = FBTangentPair(left: FBNormalizePoint(edge2Tangents.left), right: FBNormalizePoint(edge2Tangents.right))
@@ -503,7 +503,7 @@ struct FBAnglePair {
   var b: Double
 }
 
-func FBTangentsCross(edge1Tangents: FBTangentPair, edge2Tangents: FBTangentPair) -> Bool {
+func FBTangentsCross(_ edge1Tangents: FBTangentPair, edge2Tangents: FBTangentPair) -> Bool {
 
   // Calculate angles for the tangents
   let edge1Angles = FBAnglePair(a: PolarAngle(edge1Tangents.left), b: PolarAngle(edge1Tangents.right))
@@ -538,16 +538,16 @@ func FBTangentsCross(edge1Tangents: FBTangentPair, edge2Tangents: FBTangentPair)
 }
 
 
-func FBLineBoundsMightOverlap(bounds1: CGRect, bounds2: CGRect) -> Bool
+func FBLineBoundsMightOverlap(_ bounds1: CGRect, bounds2: CGRect) -> Bool
 {
-  let left = Double(max(CGRectGetMinX(bounds1), CGRectGetMinX(bounds2)))
-  let right = Double(min(CGRectGetMaxX(bounds1), CGRectGetMaxX(bounds2)))
+  let left = Double(max(bounds1.minX, bounds2.minX))
+  let right = Double(min(bounds1.maxX, bounds2.maxX))
 
   if FBIsValueGreaterThanWithOptions(left, minimum: right, threshold: FBBoundsClosenessThreshold) {
     return false    // no horizontal overlap
   }
 
-  let top = Double(max(CGRectGetMinY(bounds1), CGRectGetMinY(bounds2)))
-  let bottom = Double(min(CGRectGetMaxY(bounds1), CGRectGetMaxY(bounds2)))
+  let top = Double(max(bounds1.minY, bounds2.minY))
+  let bottom = Double(min(bounds1.maxY, bounds2.maxY))
   return FBIsValueLessThanEqualWithOptions(top, maximum: bottom, threshold: FBBoundsClosenessThreshold)
 }

--- a/Swift VectorBoolean/ViewController.swift
+++ b/Swift VectorBoolean/ViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ViewController: UIViewController, UIPickerViewDelegate {
+class ViewController: UIViewController, UIPickerViewDelegate, UIAdaptivePresentationControllerDelegate {
 
   @IBOutlet var canvasView: CanvasView!
   @IBOutlet var operationLabel: UILabel!
@@ -37,7 +37,7 @@ class ViewController: UIViewController, UIPickerViewDelegate {
       }
     }
   }
-  private var shapeData = TestShapeData()
+  fileprivate var shapeData = TestShapeData()
   var currentShapesetIndex : Int = 0
 
 
@@ -46,7 +46,7 @@ class ViewController: UIViewController, UIPickerViewDelegate {
 
     // CREDIT: This concept comes from Matt Neuburg's
     // Stack Overflow answer: http://stackoverflow.com/a/24344459
-    let envDict = NSProcessInfo.processInfo().environment
+    let envDict = ProcessInfo.processInfo.environment
     if envDict["TESTING"] != nil {
       self.blankDisplay = true
     }
@@ -67,34 +67,34 @@ class ViewController: UIViewController, UIPickerViewDelegate {
   func updateCanvas() {
     canvasView.clear()
     operationLabel.text = "Original"
-    canvasView.displayMode = .Original
+    canvasView.displayMode = .original
     segmentedControl.selectedSegmentIndex = 0
     loadCanvas()
     canvasView.setNeedsDisplay()
   }
 
   func popClosed() {
-    shapesButton.enabled = true
-    optionsButton.enabled = true
+    shapesButton.isEnabled = true
+    optionsButton.isEnabled = true
   }
 
-  @IBAction func modeSelect(sender: UISegmentedControl) {
+  @IBAction func modeSelect(_ sender: UISegmentedControl) {
     switch segmentedControl.selectedSegmentIndex {
     case 0:
       self.operationLabel.text = "Original"
-      canvasView.displayMode = .Original
+      canvasView.displayMode = .original
     case 1:
       self.operationLabel.text = "Union"
-      canvasView.displayMode = .Union
+      canvasView.displayMode = .union
     case 2:
       self.operationLabel.text = "Intersect"
-      canvasView.displayMode = .Intersect
+      canvasView.displayMode = .intersect
     case 3:
       self.operationLabel.text = "Subtract"
-      canvasView.displayMode = .Subtract
+      canvasView.displayMode = .subtract
     case 4:
       self.operationLabel.text = "Join"
-      canvasView.displayMode = .Join
+      canvasView.displayMode = .join
     default:
       self.operationLabel.text = "Unknown"
     }
@@ -134,7 +134,7 @@ class ViewController: UIViewController, UIPickerViewDelegate {
     canvasView.boundsOfPaths = current.boundsOfPaths
   }
 
-  override func shouldPerformSegueWithIdentifier(identifier: String, sender: AnyObject?) -> Bool {
+  override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
     if identifier == "showShapeSelector" {
       return true
     } else if identifier == "showOptions" {
@@ -143,13 +143,13 @@ class ViewController: UIViewController, UIPickerViewDelegate {
     return true
   }
 
-  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
     if segue.identifier == "showShapeSelector" {
-      if let destNav = segue.destinationViewController as? UINavigationController {
+      if let destNav = segue.destination as? UINavigationController {
         if let popPC = destNav.popoverPresentationController {
           popPC.passthroughViews = nil
           popPC.delegate = self
-          optionsButton.enabled = false
+          optionsButton.isEnabled = false
         }
         if let vc = destNav.topViewController as? ShapesTableViewController {
           vc.shapeData = self.shapeData
@@ -158,11 +158,11 @@ class ViewController: UIViewController, UIPickerViewDelegate {
         }
       }
     } else if segue.identifier == "showOptions" {
-      if let destNav = segue.destinationViewController as? UINavigationController {
+      if let destNav = segue.destination as? UINavigationController {
         if let popPC = destNav.popoverPresentationController {
           popPC.passthroughViews = nil
           popPC.delegate = self
-          shapesButton.enabled = false
+          shapesButton.isEnabled = false
         }
         if let vc = destNav.topViewController as? OptionsViewController {
           vc.primeVC = self
@@ -171,20 +171,21 @@ class ViewController: UIViewController, UIPickerViewDelegate {
     }
   }
 
-  func adaptivePresentationStyleForPresentationController(controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+	
+  func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
     // Give the popover a PresentationStyle.None for iPhone
-    return UIModalPresentationStyle.None
+    return .none
   }
 
 }
 
 extension ViewController: UIPopoverPresentationControllerDelegate {
 
-  func popoverPresentationControllerDidDismissPopover(popoverPresentationController: UIPopoverPresentationController) {
+  func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
     popClosed()
   }
 
-  func presentationController(controller: UIPresentationController, viewControllerForAdaptivePresentationStyle style: UIModalPresentationStyle) -> UIViewController? {
+  func presentationController(_ controller: UIPresentationController, viewControllerForAdaptivePresentationStyle style: UIModalPresentationStyle) -> UIViewController? {
 
     let nav = UINavigationController(rootViewController: controller.presentedViewController)
     return nav

--- a/Swift VectorBooleanTests/FBGeometryTests.swift
+++ b/Swift VectorBooleanTests/FBGeometryTests.swift
@@ -246,7 +246,7 @@ class FBGeometryTests: XCTestCase {
 
   func testPerformanceExample() {
     // This is an example of a performance test case.
-    self.measureBlock() {
+    self.measure() {
       // Put the code you want to measure the time of here.
     }
   }

--- a/Swift VectorBooleanTests/Swift_VectorBooleanTests.swift
+++ b/Swift VectorBooleanTests/Swift_VectorBooleanTests.swift
@@ -28,7 +28,7 @@ class Swift_VectorBooleanTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        self.measure() {
             // Put the code you want to measure the time of here.
         }
     }


### PR DESCRIPTION
This pull request upgrades the whole project, including unit tests, to Swift 3.0.
The majority of the conversion was done by the Swift migrator in Xcode.
In my quick test runs, everything seems to work and behave as before.

I've also added some @discardableResult annotations where I felt confident that they were appropriate.

Please note that currently there are 6 failures when running the unit tests. These are not new in this Swift 3.0 upgrade, these are present in the current, Swift 2.2, version.
