### PR TITLE
scott@pixiteapps.com

### DIFF
--- a/Swift VectorBoolean.xcodeproj/project.pbxproj
+++ b/Swift VectorBoolean.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 				TargetAttributes = {
 					6356E1771B4CD83A00420351 = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = ZBQGXUCEGE;
+						DevelopmentTeam = EQRQCAG846;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -613,7 +613,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = ZBQGXUCEGE;
+				DEVELOPMENT_TEAM = EQRQCAG846;
 				INFOPLIST_FILE = "Swift VectorBoolean/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.starside.$(PRODUCT_NAME:rfc1034identifier)";
@@ -629,7 +629,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = ZBQGXUCEGE;
+				DEVELOPMENT_TEAM = EQRQCAG846;
 				INFOPLIST_FILE = "Swift VectorBoolean/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.starside.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Swift VectorBoolean/CanvasView.swift
+++ b/Swift VectorBoolean/CanvasView.swift
@@ -295,11 +295,11 @@ class CanvasView: UIView {
   }
 
   fileprivate func drawUnion() {
-    if _unionPath == nil {
+    //if _unionPath == nil {
       if paths.count == 2 {
         _unionPath = paths[0].path.fb_union(paths[1].path)
       }
-    }
+    //}
     if let path = _unionPath {
       vectorFillColor.setFill()
       vectorStrokeColor.setStroke()
@@ -313,11 +313,11 @@ class CanvasView: UIView {
   }
 
   fileprivate func drawIntersect() {
-    if _intersectPath == nil {
+    //if _intersectPath == nil {
       if paths.count == 2 {
         _intersectPath = paths[0].path.fb_intersect(paths[1].path)
       }
-    }
+    //}
     if let path = _intersectPath {
       vectorFillColor.setFill()
       vectorStrokeColor.setStroke()
@@ -331,11 +331,11 @@ class CanvasView: UIView {
   }
 
   fileprivate func drawSubtract() {
-    if _differencePath == nil {
+    //if _differencePath == nil {
       if paths.count == 2 {
         _differencePath = paths[0].path.fb_difference(paths[1].path)
       }
-    }
+    //}
     if let path = _differencePath {
       vectorFillColor.setFill()
       vectorStrokeColor.setStroke()

--- a/Swift VectorBoolean/TestShapes.swift
+++ b/Swift VectorBoolean/TestShapes.swift
@@ -69,15 +69,16 @@ class TestShapeData {
     TestShape_Complex_Shapes(),                   // 8
     TestShape_Complex_Shapes2(),                  // 9
     TestShape_Triangle_Inside_Rectangle(),        // 10
-    TestShape_Diamond_Overlapping_Rectangle(),    // 11
-    TestShape_Diamond_Inside_Rectangle(),         // 12
-    TestShape_Non_Overlapping_Contours(),         // 13
-    TestShape_More_Non_Overlapping_Contours(),    // 14
-    TestShape_Concentric_Contours(),              // 15
-    TestShape_More_Concentric_Contours(),         // 16
-    TestShape_Circle_Overlapping_Hole(),          // 17
-    TestShape_Rect_w_Hole_Over_Rect_w_Hole(),     // 18
-    TestShape_Curve_Overlapping_Rectangle(),      // 19
+    TestShape_Rectangle_Overlap_Rectangle(),      // 11
+    TestShape_Diamond_Overlapping_Rectangle(),    // 12
+    TestShape_Diamond_Inside_Rectangle(),         // 13
+    TestShape_Non_Overlapping_Contours(),         // 14
+    TestShape_More_Non_Overlapping_Contours(),    // 15
+    TestShape_Concentric_Contours(),              // 16
+    TestShape_More_Concentric_Contours(),         // 17
+    TestShape_Circle_Overlapping_Hole(),          // 18
+    TestShape_Rect_w_Hole_Over_Rect_w_Hole(),     // 19
+    TestShape_Curve_Overlapping_Rectangle(),      // 20
     TestShape_Debug(),
     TestShape_DebugQuadCurve(),
     TestShape_Debug001(),
@@ -293,6 +294,21 @@ class TestShape_Triangle_Inside_Rectangle : TestShape, SampleShapeMaker {
     path.close()
     return path
   }
+}
+
+class TestShape_Rectangle_Overlap_Rectangle : TestShape, SampleShapeMaker {
+    
+    init() {
+        super.init(label: "Rectangle Overlap Rectangle")
+    }
+    
+    func otherShapes() -> UIBezierPath {
+        return UIBezierPath(rect: CGRect(x: 100, y: 100, width: 300, height: 300))
+    }
+    
+    func topShape() -> UIBezierPath {
+        return UIBezierPath(rect: CGRect(x: 250, y: 100, width: 300, height: 300))
+    }
 }
 
 class TestShape_Diamond_Overlapping_Rectangle : TestShape, SampleShapeMaker {

--- a/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Boolean.swift
+++ b/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Boolean.swift
@@ -17,8 +17,12 @@ public extension UIBezierPath {
   func fb_union(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
+    
+    thisGraph.fixWindingsForNonZeroFill()
+    otherGraph.fixWindingsForNonZeroFill()
+    
     let resultGraph = thisGraph.unionWithBezierGraph(otherGraph)!
-    let result = resultGraph.bezierPath
+    let result = resultGraph.bezierPath(nonZeroWinding: true)
     result.fb_copyAttributesFrom(self)
     return result
   }
@@ -28,7 +32,11 @@ public extension UIBezierPath {
   func fb_intersect(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
-    let result = thisGraph.intersectWithBezierGraph(otherGraph).bezierPath
+    
+    thisGraph.fixWindingsForNonZeroFill()
+    otherGraph.fixWindingsForNonZeroFill()
+    
+    let result = thisGraph.intersectWithBezierGraph(otherGraph).bezierPath(nonZeroWinding: true)
     result.fb_copyAttributesFrom(self)
     return result
   }
@@ -38,7 +46,11 @@ public extension UIBezierPath {
   func fb_difference(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
-    let result = thisGraph.differenceWithBezierGraph(otherGraph).bezierPath
+    
+    thisGraph.fixWindingsForNonZeroFill()
+    otherGraph.fixWindingsForNonZeroFill()
+    
+    let result = thisGraph.differenceWithBezierGraph(otherGraph).bezierPath(nonZeroWinding: true)
     result.fb_copyAttributesFrom(self)
     return result
   }
@@ -48,7 +60,11 @@ public extension UIBezierPath {
   func fb_xor(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
-    let result = thisGraph.xorWithBezierGraph(otherGraph).bezierPath
+    
+    thisGraph.fixWindingsForNonZeroFill()
+    otherGraph.fixWindingsForNonZeroFill()
+    
+    let result = thisGraph.xorWithBezierGraph(otherGraph).bezierPath(nonZeroWinding: true)
     result.fb_copyAttributesFrom(self)
     return result
   }

--- a/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Boolean.swift
+++ b/Swift VectorBoolean/VectorBoolean/BezierExtensions/UIBezierPath_Boolean.swift
@@ -33,6 +33,9 @@ public extension UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
     
+    thisGraph.removeOverlaps()
+    otherGraph.removeOverlaps()
+    
     thisGraph.fixWindingsForNonZeroFill()
     otherGraph.fixWindingsForNonZeroFill()
     
@@ -46,6 +49,9 @@ public extension UIBezierPath {
   func fb_difference(_ path: UIBezierPath) -> UIBezierPath {
     let thisGraph = FBBezierGraph(path: self)
     let otherGraph = FBBezierGraph(path: path)
+    
+    thisGraph.removeOverlaps()
+    otherGraph.removeOverlaps()
     
     thisGraph.fixWindingsForNonZeroFill()
     otherGraph.fixWindingsForNonZeroFill()

--- a/Swift VectorBoolean/VectorBoolean/FBBezierContour.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierContour.swift
@@ -556,19 +556,13 @@ class FBBezierContour {
   //- (FBContourDirection) direction
   var direction : FBContourDirection {
 
-    var lastPoint = CGPoint.zero, currentPoint = CGPoint.zero
-    var firstPoint = true
+    // re-written by scott sykora to use algo from here:
+    // http://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-points-are-in-clockwise-order
+    
   	var a = CGFloat(0.0)
 
     for edge in _edges {
-      if firstPoint {
-        lastPoint = edge.endPoint1
-        firstPoint = false
-      } else {
-        currentPoint = edge.endPoint2
-        a += ((lastPoint.x * currentPoint.y) - (currentPoint.x * lastPoint.y))
-        lastPoint = currentPoint
-      }
+        a += (edge.endPoint2.x - edge.endPoint1.x) * (edge.endPoint2.y + edge.endPoint1.y);
     }
 
     return ( a >= 0 ) ? FBContourDirection.clockwise : FBContourDirection.antiClockwise

--- a/Swift VectorBoolean/VectorBoolean/FBBezierContour.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierContour.swift
@@ -544,7 +544,7 @@ class FBBezierContour {
   var reversedContour : FBBezierContour {
     let revContour = FBBezierContour()
 
-    for edge in _edges {
+    for edge in _edges.reversed() {
       revContour.addReverseCurve(edge)
     }
 

--- a/Swift VectorBoolean/VectorBoolean/FBBezierCurve.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierCurve.swift
@@ -2408,7 +2408,7 @@ public class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertib
       let time = offset / len
       let pap = _data.pointAtParameter(time)
       if let curve = pap.rightCurve {
-        return FBSubtractPoint(curve.controlPoint2, point2: curve.endPoint2)
+        return FBSubtractPoint(curve.controlPoint1, point2: curve.endPoint1)
       }
     }
 

--- a/Swift VectorBoolean/VectorBoolean/FBBezierCurve_Edge.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierCurve_Edge.swift
@@ -342,11 +342,6 @@ extension FBBezierCurve {
       return true
     }
     
-    // if these are both straight lines, then they always cross // ADDED BY Scott to fix side by side squares. not sure if this is right
-    if(isStraightLine && edge2.isStraightLine) {
-        return true;
-    }
-
     // The intersection happens at the end of one of the edges, meaning we'll
     // have to look at the next edge in sequence to see if it crosses or not.
     // We'll do that by computing the four tangents at the exact point the
@@ -364,22 +359,34 @@ extension FBBezierCurve {
     var edge2Tangents = FBTangentPair(left: CGPoint.zero, right: CGPoint.zero)
     var offset = 0.0
 
-    let (edge1LeftCurve, edge1RightCurve) = FBFindEdge1TangentCurves(self, intersection: intersection)
+    var (edge1LeftCurve, edge1RightCurve) = FBFindEdge1TangentCurves(self, intersection: intersection)
     let edge1Length = min(edge1LeftCurve.length(), edge1RightCurve.length())
 
-    let (edge2LeftCurve, edge2RightCurve) = FBFindEdge2TangentCurves(edge2, intersection: intersection)
+    var (edge2LeftCurve, edge2RightCurve) = FBFindEdge2TangentCurves(edge2, intersection: intersection)
     let edge2Length = min(edge2LeftCurve.length(), edge2RightCurve.length())
 
     let maxOffset = min(edge1Length, edge2Length)
+    let offsetIncrement = maxOffset / 10
+    
+    // if these are both straight lines and are ambigious then we need to go to the next edge in the sequence and see if those cross, instead of using the offset
+    if isStraightLine && edge2.isStraightLine {
 
-    repeat {
-      FBComputeEdgeTangents(edge1LeftCurve, rightCurve: edge1RightCurve, offset: offset, edgeTangents: &edge1Tangents)
-      FBComputeEdgeTangents(edge2LeftCurve, rightCurve: edge2RightCurve, offset: offset, edgeTangents: &edge2Tangents)
+        FBComputeEdgeTangents(edge1LeftCurve, rightCurve: edge1RightCurve, offset: 0, edgeTangents: &edge1Tangents)
+        FBComputeEdgeTangents(edge2LeftCurve, rightCurve: edge2RightCurve, offset: 0, edgeTangents: &edge2Tangents)
 
-      offset += 1.0
-    } while FBAreTangentsAmbigious(edge1Tangents, edge2Tangents: edge2Tangents) && offset < maxOffset
+    }
 
-    return FBTangentsCross(edge1Tangents, edge2Tangents: edge2Tangents)
+    else {
+        repeat {
+            FBComputeEdgeTangents(edge1LeftCurve, rightCurve: edge1RightCurve, offset: offset, edgeTangents: &edge1Tangents)
+            FBComputeEdgeTangents(edge2LeftCurve, rightCurve: edge2RightCurve, offset: offset, edgeTangents: &edge2Tangents)
+            
+            offset += offsetIncrement
+        } while FBAreTangentsAmbigious(edge1Tangents, edge2Tangents: edge2Tangents) && offset < maxOffset
+    }
+
+    let crosses = FBTangentsCross(edge1Tangents, edge2Tangents: edge2Tangents)
+    return crosses
   }
 
   // 332

--- a/Swift VectorBoolean/VectorBoolean/FBBezierCurve_Edge.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierCurve_Edge.swift
@@ -341,6 +341,11 @@ extension FBBezierCurve {
     if !intersection.isAtEndPointOfCurve {
       return true
     }
+    
+    // if these are both straight lines, then they always cross // ADDED BY Scott to fix side by side squares. not sure if this is right
+    if(isStraightLine && edge2.isStraightLine) {
+        return true;
+    }
 
     // The intersection happens at the end of one of the edges, meaning we'll
     // have to look at the next edge in sequence to see if it crosses or not.

--- a/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
@@ -599,7 +599,7 @@ class FBBezierGraph {
   var bezierPath : UIBezierPath {
     return bezierPath(nonZeroWinding: false)
   }
-
+    
     func bezierPath(nonZeroWinding:Bool) -> UIBezierPath {
         // Convert this graph into a bezier path. This is straightforward, each contour
         //  starting with a move to and each subsequent edge being translated by doing
@@ -607,7 +607,7 @@ class FBBezierGraph {
         // Be sure to mark the winding rule as even-odd, or interior contours (holes)
         //  won't get filled/left alone properly.
         let path = UIBezierPath()
-        path.usesEvenOddFillRule = false
+        path.usesEvenOddFillRule = !nonZeroWinding
         
         for contour in _contours {
             var firstPoint = true
@@ -622,7 +622,6 @@ class FBBezierGraph {
             } else {
                 fixedContour = contour
             }
-            
             
             for edge in fixedContour.edges {
                 if firstPoint {
@@ -892,13 +891,11 @@ class FBBezierGraph {
     // Added by Scott Sykora. Needed to clean up bezier paths that have wrong windings
     func fixWindingsForNonZeroFill() {
         // reverse any contours that are needed to keep non-zero winding rule working
-        
-        removeCrossings()
-        insertSelfCrossings() // this will set contour insides correctly
-        
+                
         var fixedContours = [FBBezierContour]()
         
         for contour in _contours {
+            contour.inside = contourInsides(contour)
             let isInside = contour.inside == .hole
             let isClockwise = contour.direction == .clockwise
             
@@ -908,10 +905,8 @@ class FBBezierGraph {
                 fixedContours.append(contour)
             }
         }
-        
+
         _contours = fixedContours
-        
-        removeCrossings()
     }
 
   // 750
@@ -1715,7 +1710,7 @@ class FBBezierGraph {
 
   // 1307
   //- (void) removeOverlaps
-  fileprivate func removeOverlaps() {
+  func removeOverlaps() {
     for contour in _contours {
       contour.removeAllOverlaps()
     }

--- a/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierGraph.swift
@@ -868,6 +868,31 @@ class FBBezierGraph {
       contour.inside = contourInsides(contour)
     }
   }
+    
+    // Added by Scott Sykora. Needed to clean up bezier paths that have wrong windings
+    func fixWindingsForNonZeroFill() {
+        // reverse any contours that are needed to keep non-zero winding rule working
+        
+        removeCrossings()
+        insertSelfCrossings() // this will set contour insides correctly
+        
+        var fixedContours = [FBBezierContour]()
+        
+        for contour in _contours {
+            let isInside = contour.inside == .hole
+            let isClockwise = contour.direction == .clockwise
+            
+            if ((isInside && isClockwise) || (!isInside && !isClockwise)) {
+                fixedContours.append(contour.reversedContour)
+            } else {
+                fixedContours.append(contour)
+            }
+        }
+        
+        _contours = fixedContours
+        
+        removeCrossings()
+    }
 
   // 750
   //- (NSRect) bounds

--- a/Swift VectorBoolean/VectorBoolean/FBGeometry.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBGeometry.swift
@@ -421,7 +421,7 @@ func FBIsValueLessThanEqual(_ value: Double, maximum: Double) -> Bool {
   return FBIsValueLessThanEqualWithOptions(value, maximum: maximum, threshold: FBTangentClosenessThreshold)
 }
 
-
+// Scott changed this to contain an angle if the range is equal
 func FBAngleRangeContainsAngle(_ range: FBAngleRange, angle: Double) -> Bool {
 
   if range.minimum <= range.maximum {


### PR DESCRIPTION
This adds support for non-zero winding rules of bezier curves, which is what CAShapeLayer uses by default and what we use in our app "Assembly"

CAShapeLayer does support even odd fills, but as far as I can tell this breaks it's shadow functionality which we use in our app.

I've added most of the logic to the UIBezierPath extension layer, since that is the closest to where we need to convert back to a non-zero winding shape. That code now calls new fixWindingsForNonZeroFill() and bezierPath(nonZeroWinding: Bool) methods which let us fix incoming paths and then export correctly formatted paths.

This pull request also fixes the "reversedContour" function on FBBezierContour which was broken because it didn't actually revers the order of the points, just their individual control handles.

This is my first pull request ever on github, so please forgive me if I'm not following protocol or if i Should go about this very differently.