### PR TITLE
Fix for "Circle on Rectangle" issue

### DIFF
--- a/Swift VectorBoolean/VectorBoolean/FBBezierCurve.swift
+++ b/Swift VectorBoolean/VectorBoolean/FBBezierCurve.swift
@@ -2408,7 +2408,7 @@ public class FBBezierCurve : CustomDebugStringConvertible, CustomStringConvertib
       let time = offset / len
       let pap = _data.pointAtParameter(time)
       if let curve = pap.rightCurve {
-        return FBSubtractPoint(curve.controlPoint2, point2: curve.endPoint2)
+        return FBSubtractPoint(curve.controlPoint1, point2: curve.endPoint1)
       }
     }
 


### PR DESCRIPTION
This fixes a one line bug in the code used to compute if tangent lines cross each other. It was causing the weirdness seen in the "Circle on Rectangle" test case and probably some other things.